### PR TITLE
Fix YAML validation in config

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/encoding/yaml"
 )
@@ -19,7 +18,11 @@ func ValidateWithCue(configFile, cueFile string) error {
 	if err != nil {
 		return fmt.Errorf("cannot read YAML config: %w", err)
 	}
-	configVal := ctx.CompileBytes(yamlBytes, yaml.Parse)
+	yamlFile, err := yaml.Extract(configFile, yamlBytes)
+	if err != nil {
+		return fmt.Errorf("cannot parse YAML config: %w", err)
+	}
+	configVal := ctx.BuildFile(yamlFile)
 
 	// Read CUE schema
 	schemaBytes, err := os.ReadFile(cueFile)


### PR DESCRIPTION
## Summary
- use `yaml.Extract` with `Context.BuildFile` for cue validation
- remove unused cue import

## Testing
- `go test ./...` *(fails: undefined symbols in greptime_writer.go)*

------
https://chatgpt.com/codex/tasks/task_e_68836cf9a4248323b3ab0338961391bc