### PR TITLE
fix(codex): parameterize table name via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ cue vet config/fleet.yaml schemas/fleet.cue
 
 ### Environment Variables
 
--	`GREPTIMEDB_ENDPOINT` → If set, telemetry is written to this GreptimeDB endpoint
+-       `GREPTIMEDB_ENDPOINT` → If set, telemetry is written to this GreptimeDB endpoint
+-       `GREPTIMEDB_TABLE` → Target table for telemetry (default: drone_telemetry)
 -	`CLUSTER_ID` → Cluster identity tag (default: mission-01)
 
 ## Quickstart
@@ -80,6 +81,7 @@ make build
 
 ```bash
 export GREPTIMEDB_ENDPOINT=127.0.0.1:4001
+export GREPTIMEDB_TABLE=drone_telemetry
 ./build/droneops-sim
 ```
 
@@ -89,6 +91,7 @@ Docker run:
 docker build -t droneops-sim:latest .
 docker run --rm \
     -e GREPTIMEDB_ENDPOINT=127.0.0.1:4001 \
+    -e GREPTIMEDB_TABLE=drone_telemetry \
     droneops-sim:latest
 ```
 

--- a/cmd/droneops-sim/main.go
+++ b/cmd/droneops-sim/main.go
@@ -32,7 +32,8 @@ func main() {
 		writer = &sim.StdoutWriter{}
 	} else {
 		endpoint := os.Getenv("GREPTIMEDB_ENDPOINT")
-		writer, err = sim.NewGreptimeDBWriter(endpoint, "public")
+		table := os.Getenv("GREPTIMEDB_TABLE")
+		writer, err = sim.NewGreptimeDBWriter(endpoint, "public", table)
 		if err != nil {
 			log.Fatalf("Failed to init GreptimeDB writer: %v", err)
 		}

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -23,6 +23,8 @@ spec:
         env:
         - name: GREPTIMEDB_ENDPOINT
           value: "127.0.0.1:4001"   # override for real deployments
+        - name: GREPTIMEDB_TABLE
+          value: "drone_telemetry"
         - name: CLUSTER_ID
           value: "mission-01"
         volumeMounts:

--- a/internal/sim/greptime_writer.go
+++ b/internal/sim/greptime_writer.go
@@ -19,7 +19,7 @@ type GreptimeDBWriter struct {
 }
 
 // NewGreptimeDBWriter creates a new GreptimeDB writer.
-func NewGreptimeDBWriter(endpoint, database string) (*GreptimeDBWriter, error) {
+func NewGreptimeDBWriter(endpoint, database, table string) (*GreptimeDBWriter, error) {
 	cfg := greptime.NewConfig(endpoint).
 		WithPort(4001).
 		WithDatabase(database)
@@ -30,10 +30,14 @@ func NewGreptimeDBWriter(endpoint, database string) (*GreptimeDBWriter, error) {
 
 	// Table creation must be done outside this code (via SQL API or manually).
 
+	if table == "" {
+		table = telemetry.TelemetryTableName
+	}
+
 	return &GreptimeDBWriter{
 		client: client,
 		db:     database,
-		table:  "drone_telemetry",
+		table:  table,
 	}, nil
 }
 

--- a/internal/telemetry/types.go
+++ b/internal/telemetry/types.go
@@ -1,7 +1,10 @@
 // Telemetry structs with greptime tags
 package telemetry
 
-import "time"
+import (
+	"os"
+	"time"
+)
 
 // TelemetryRow represents one telemetry record for GreptimeDB.
 type TelemetryRow struct {
@@ -18,9 +21,18 @@ type TelemetryRow struct {
 	Timestamp  time.Time `json:"ts"`          // TIME INDEX
 }
 
-// TableName returns the target table name for ORM mapping.
-func (TelemetryRow) TableName() string {
+// TelemetryTableName holds the table name used when writing to GreptimeDB.
+// It defaults to "drone_telemetry" but can be overridden via the
+// GREPTIMEDB_TABLE environment variable.
+var TelemetryTableName = func() string {
+	if env := os.Getenv("GREPTIMEDB_TABLE"); env != "" {
+		return env
+	}
 	return "drone_telemetry"
+}()
+
+func (TelemetryRow) TableName() string {
+	return TelemetryTableName
 }
 
 // Drone holds runtime state for a simulated drone.


### PR DESCRIPTION
## Summary
- allow overriding telemetry table name via `GREPTIMEDB_TABLE`
- wire table env var through greptime writer and main
- document new variable and update usage instructions
- update deployment example with table env var

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688374070c648323b02f64bf8f2c2853