### PR TITLE
Switch to simulation.yaml config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ run:
 	@if [ ! -f $(BIN) ]; then \
 		$(MAKE) build; \
 	fi
-	$(BIN) --config config/fleet.yaml --schema schemas/fleet.cue --print-only
+       $(BIN) --config config/simulation.yaml --schema schemas/simulation.cue --print-only
 
 docker:
 	docker build -t $(APP_NAME):latest .

--- a/README.md
+++ b/README.md
@@ -25,17 +25,23 @@ This project was designed to support visualization dashboards (e.g., Grafana Geo
 
 ## Configuration
 
-### Fleet Configuration (`config/fleet.yaml`)
+### Simulation Configuration (`config/simulation.yaml`)
 
-Defines regions and fleets:
+Defines zones, missions and fleets:
 
 ```yaml
-regions:
+zones:
   - name: central-europe
     center_lat: 48.2
     center_lon: 16.4
     radius_km: 300
-
+missions:
+  - name: surveillance-alpha
+    zone: central-europe
+    description: Recon and patrol of key areas
+  - name: cargo-beta
+    zone: central-europe
+    description: Deliver supplies between bases
 fleets:
   - name: recon-swarm
     model: small-fpv
@@ -49,24 +55,25 @@ fleets:
       speed_max_kmh: 90
 ```
 
-## Schema Validation (schemas/fleet.cue)
+## Schema Validation (schemas/simulation.cue)
 
 Configuration is validated at runtime using CUE:
 
-cue vet config/fleet.yaml schemas/fleet.cue
+cue vet config/simulation.yaml schemas/simulation.cue
 
 ## Entry Point
 
 ### CLI Flags
 
 - `--print-only` → Print telemetry JSON to STDOUT (ignores DB)
-- `--config` → Path to YAML config (default: config/fleet.yaml)
-- `--schema` → Path to CUE schema (default: schemas/fleet.cue)
+ - `--config` → Path to YAML config (default: config/simulation.yaml)
+ - `--schema` → Path to CUE schema (default: schemas/simulation.cue)
 
 ### Environment Variables
 
 - `GREPTIMEDB_ENDPOINT` → If set, telemetry is written to this GreptimeDB endpoint
 - `GREPTIMEDB_TABLE` → Target table for telemetry (default: drone_telemetry)
+- `MISSION_METADATA_TABLE` → Table storing mission metadata (default: mission_metadata)
 - `CLUSTER_ID` → Cluster identity tag (default: mission-01)
 
 ## Quickstart
@@ -110,7 +117,7 @@ docker run --rm \
 flowchart TD
     Start["Start"] -->|"main.go"| A["Parse flags & env"]
     A -->|"config.go"| B["Load config"]
-    B -->|"schemas/fleet.cue"| C["Validate with CUE"]
+    B -->|"schemas/simulation.cue"| C["Validate with CUE"]
     C -->|"simulator.go"| D["Create simulator"]
     D -->|"Simulator.Run loop"| E["Create drones for fleets"]
     E -->|"generator.go"| F["Generate telemetry"]
@@ -136,7 +143,7 @@ flowchart TD
 - Validate config manually:
 
 ```bash
-cue vet config/fleet.yaml schemas/fleet.cue
+cue vet config/simulation.yaml schemas/simulation.cue
 ```
 
 Test:
@@ -162,7 +169,7 @@ The `droneops-sim` project includes a Helm chart for deploying the simulator in 
 
 3. **Customize values**:
 
-   Edit the `values.yaml` file to configure replicas, image, service type, resources, and fleet configuration.
+   Edit the `values.yaml` file to configure replicas, image, service type, resources, and simulation configuration.
 
 4. **Deploy the chart**:
 
@@ -192,7 +199,7 @@ The `droneops-sim` project includes a Helm chart for deploying the simulator in 
 
 ### Notes
 
-- The Helm chart uses ConfigMaps to manage fleet and schema configurations.
+ - The Helm chart uses ConfigMaps to manage simulation and schema configurations.
 - Ensure the Kubernetes cluster has sufficient resources to handle the configured replicas and resource limits.
 - Update the `GREPTIMEDB_ENDPOINT` and `GREPTIMEDB_TABLE` environment variables in the deployment if connecting to a real database.
 

--- a/cmd/droneops-sim/main.go
+++ b/cmd/droneops-sim/main.go
@@ -15,11 +15,11 @@ import (
 func main() {
 	// CLI flags
 	printOnly := flag.Bool("print-only", false, "Print telemetry to STDOUT instead of writing to DB")
-	configPath := flag.String("config", "config/fleet.yaml", "Path to fleet configuration YAML")
-	cueSchemaPath := flag.String("schema", "schemas/fleet.cue", "Path to CUE schema file")
+	configPath := flag.String("config", "config/simulation.yaml", "Path to simulation configuration YAML")
+	cueSchemaPath := flag.String("schema", "schemas/simulation.cue", "Path to CUE schema file")
 	flag.Parse()
 
-	// Load fleet configuration
+	// Load simulation configuration
 	cfg, err := config.Load(*configPath, *cueSchemaPath)
 	if err != nil {
 		log.Fatalf("Config load failed: %v", err)

--- a/config/simulation.yaml
+++ b/config/simulation.yaml
@@ -1,10 +1,16 @@
-# Example YAML fleet configuration
-regions:
+# Example YAML simulation configuration
+zones:
   - name: central-europe
     center_lat: 48.2
     center_lon: 16.4
     radius_km: 300
-
+missions:
+  - name: surveillance-alpha
+    zone: central-europe
+    description: Recon and patrol of key areas
+  - name: cargo-beta
+    zone: central-europe
+    description: Deliver supplies between bases
 fleets:
   - name: recon-swarm
     model: small-fpv
@@ -16,7 +22,6 @@ fleets:
       failure_rate: 0.02
       speed_min_kmh: 50
       speed_max_kmh: 90
-
   - name: transport-squad
     model: medium-uav
     count: 5
@@ -27,7 +32,6 @@ fleets:
       failure_rate: 0.01
       speed_min_kmh: 80
       speed_max_kmh: 140
-
   - name: heavy-support
     model: large-uav
     count: 2

--- a/helm/droneops-sim/templates/configmap.yaml
+++ b/helm/droneops-sim/templates/configmap.yaml
@@ -3,13 +3,13 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-config
 data:
-  fleet.yaml: |
-    {{- toYaml .Values.config.fleet | nindent 4 }}
+  simulation.yaml: |
+    {{- toYaml .Values.config.simulation | nindent 4 }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-schema
 data:
-  fleet.cue: |
-    {{- toYaml .Values.schema.fleet | nindent 4 }}
+  simulation.cue: |
+    {{- toYaml .Values.schema.simulation | nindent 4 }}

--- a/helm/droneops-sim/templates/deployment.yaml
+++ b/helm/droneops-sim/templates/deployment.yaml
@@ -20,9 +20,9 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
           - "--config"
-          - "/etc/{{ .Chart.Name }}/config/fleet.yaml"
+          - "/etc/{{ .Chart.Name }}/config/simulation.yaml"
           - "--schema"
-          - "/etc/{{ .Chart.Name }}/schema/fleet.cue"
+          - "/etc/{{ .Chart.Name }}/schema/simulation.cue"
         env:
         - name: GREPTIMEDB_ENDPOINT
           value: "127.0.0.1:4001"

--- a/helm/droneops-sim/values.yaml
+++ b/helm/droneops-sim/values.yaml
@@ -18,12 +18,19 @@ resources:
     memory: "512Mi"
 
 config:
-  fleet:
-    regions:
+  simulation:
+    zones:
       - name: central-europe
         center_lat: 48.2
         center_lon: 16.4
         radius_km: 300
+    missions:
+      - name: surveillance-alpha
+        zone: central-europe
+        description: Recon and patrol of key areas
+      - name: cargo-beta
+        zone: central-europe
+        description: Deliver supplies between bases
     fleets:
       - name: recon-swarm
         model: small-fpv
@@ -57,13 +64,17 @@ config:
           speed_max_kmh: 180
 
 schema:
-  fleet:
+  simulation:
     package: schemas
-    regions:
+    zones:
       - name: string & !=""
         center_lat: number
         center_lon: number
         radius_km: number
+    missions:
+      - name: string & !=""
+        zone: string
+        description: string
     fleets:
       - name: string & !=""
         model: string & !=""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,8 +2,8 @@
 package config
 
 import (
-	"os"
 	"gopkg.in/yaml.v3"
+	"os"
 )
 
 // Behavior defines dynamic properties of a drone model/fleet
@@ -32,14 +32,22 @@ type Fleet struct {
 	Behavior        Behavior `yaml:"behavior"`
 }
 
-// FleetConfig is the root configuration for regions and fleets
-type FleetConfig struct {
-	Regions []Region `yaml:"regions"`
-	Fleets  []Fleet  `yaml:"fleets"`
+// Mission describes a named mission that operates within a zone
+type Mission struct {
+	Name        string `yaml:"name"`
+	Zone        string `yaml:"zone"`
+	Description string `yaml:"description"`
+}
+
+// SimulationConfig is the root configuration for zones, missions, and fleets
+type SimulationConfig struct {
+	Zones    []Region  `yaml:"zones"`
+	Missions []Mission `yaml:"missions"`
+	Fleets   []Fleet   `yaml:"fleets"`
 }
 
 // Load loads YAML config and validates it against a CUE schema
-func Load(configPath, cueSchemaPath string) (*FleetConfig, error) {
+func Load(configPath, cueSchemaPath string) (*SimulationConfig, error) {
 	// Validate with CUE first
 	if err := ValidateWithCue(configPath, cueSchemaPath); err != nil {
 		return nil, err
@@ -49,7 +57,7 @@ func Load(configPath, cueSchemaPath string) (*FleetConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	var cfg FleetConfig
+	var cfg SimulationConfig
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,14 +6,18 @@ import (
 )
 
 func TestLoadConfig_Valid(t *testing.T) {
-	tmpFile := "test-fleet.yaml"
+	tmpFile := "test-simulation.yaml"
 	defer os.Remove(tmpFile)
 	yaml := `
-regions:
+zones:
   - name: region-x
     center_lat: 48.2
     center_lon: 16.4
     radius_km: 50
+missions:
+  - name: test-mission
+    zone: region-x
+    description: test
 fleets:
   - name: fleet-x
     model: small-fpv
@@ -26,7 +30,7 @@ fleets:
 	}
 
 	// This test skips full CUE validation for speed, uses ValidateWithCue = no-op or mocked.
-	cfg, err := Load(tmpFile, "../../schemas/fleet.cue")
+	cfg, err := Load(tmpFile, "../../schemas/simulation.cue")
 	if err != nil {
 		t.Fatalf("Load() returned error: %v", err)
 	}

--- a/internal/sim/simulator.go
+++ b/internal/sim/simulator.go
@@ -35,7 +35,7 @@ type DroneFleet struct {
 }
 
 // NewSimulator initializes drones from fleet config.
-func NewSimulator(clusterID string, cfg *config.FleetConfig, writer TelemetryWriter, tickInterval time.Duration) *Simulator {
+func NewSimulator(clusterID string, cfg *config.SimulationConfig, writer TelemetryWriter, tickInterval time.Duration) *Simulator {
 	sim := &Simulator{
 		clusterID:    clusterID,
 		teleGen:      telemetry.NewGenerator(clusterID),
@@ -50,7 +50,7 @@ func NewSimulator(clusterID string, cfg *config.FleetConfig, writer TelemetryWri
 			drone := &telemetry.Drone{
 				ID:       generateDroneID(fleet.Name, i),
 				Model:    fleet.Model,
-				Position: telemetry.Position{Lat: cfg.Regions[0].CenterLat, Lon: cfg.Regions[0].CenterLon, Alt: 100},
+				Position: telemetry.Position{Lat: cfg.Zones[0].CenterLat, Lon: cfg.Zones[0].CenterLon, Alt: 100},
 				Battery:  100,
 				Status:   telemetry.StatusOK,
 			}

--- a/internal/sim/simulator_test.go
+++ b/internal/sim/simulator_test.go
@@ -19,8 +19,9 @@ func (w *MockWriter) Write(row telemetry.TelemetryRow) error {
 }
 
 func TestSimulator_TickGeneratesTelemetry(t *testing.T) {
-	cfg := &config.FleetConfig{
-		Regions: []config.Region{{Name: "region-1", CenterLat: 48.2, CenterLon: 16.4, RadiusKM: 50}},
+	cfg := &config.SimulationConfig{
+		Zones:    []config.Region{{Name: "region-1", CenterLat: 48.2, CenterLon: 16.4, RadiusKM: 50}},
+		Missions: []config.Mission{{Name: "m1", Zone: "region-1", Description: "test"}},
 		Fleets: []config.Fleet{
 			{Name: "fleet-1", Model: "small-fpv", Count: 3, MovementPattern: "patrol", HomeRegion: "region-1"},
 		},

--- a/schemas/simulation.cue
+++ b/schemas/simulation.cue
@@ -1,11 +1,17 @@
-// CUE schema content for fleet.yaml
+// CUE schema content for simulation.yaml
 package schemas
 
-regions: [...{
+zones: [...{
     name:        string & !=""
     center_lat:  number
     center_lon:  number
     radius_km:   number & >0
+}]
+
+missions: [...{
+    name:        string & !=""
+    zone:        string
+    description: string
 }]
 
 fleets: [...{


### PR DESCRIPTION
## Summary
- rename fleet.yaml/schema to simulation.yaml
- describe zones and missions in the config and schema
- change defaults and docs to use simulation.yaml
- mount new files via Helm chart
- add mission metadata env variable docs

## Testing
- `go test ./... -v`

------
https://chatgpt.com/codex/tasks/task_e_68847bf4ff9c8323ad4a54971ab9161d