### PR TITLE
feat(codex): Add configurable tick interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ cue vet config/simulation.yaml schemas/simulation.cue
 - `--print-only` → Print telemetry JSON to STDOUT (ignores DB)
 - `--config` → Path to YAML config (default: config/simulation.yaml)
 - `--schema` → Path to CUE schema (default: schemas/simulation.cue)
+- `--tick` → Telemetry tick interval (default: 1s)
 
 ### Environment Variables
 
@@ -117,6 +118,7 @@ cue vet config/simulation.yaml schemas/simulation.cue
 - `GREPTIMEDB_TABLE` → Target table for telemetry (default: drone_telemetry)
 - `MISSION_METADATA_TABLE` → Table storing mission metadata (default: mission_metadata)
 - `CLUSTER_ID` → Cluster identity tag (default: mission-01)
+- `TICK_INTERVAL` → Telemetry tick interval in Go duration format (overrides `--tick`)
 
 ## Quickstart
 

--- a/cmd/droneops-sim/main.go
+++ b/cmd/droneops-sim/main.go
@@ -18,6 +18,7 @@ func main() {
 	printOnly := flag.Bool("print-only", false, "Print telemetry to STDOUT instead of writing to DB")
 	configPath := flag.String("config", "config/simulation.yaml", "Path to simulation configuration YAML")
 	cueSchemaPath := flag.String("schema", "schemas/simulation.cue", "Path to CUE schema file")
+	tickFlag := flag.Duration("tick", time.Second, "Telemetry tick interval (e.g. 500ms, 2s)")
 	flag.Parse()
 
 	// Load simulation configuration
@@ -47,7 +48,16 @@ func main() {
 	}
 
 	// Simulator setup
-	simulator := sim.NewSimulator(clusterID, cfg, writer, 1*time.Second)
+	tickInterval := *tickFlag
+	if envTick := os.Getenv("TICK_INTERVAL"); envTick != "" {
+		d, err := time.ParseDuration(envTick)
+		if err != nil {
+			log.Fatalf("Invalid TICK_INTERVAL: %v", err)
+		}
+		tickInterval = d
+	}
+
+	simulator := sim.NewSimulator(clusterID, cfg, writer, tickInterval)
 
 	// Start admin UI
 	go func() {


### PR DESCRIPTION
## Summary
- allow telemetry tick interval to be configured via `--tick` flag or `TICK_INTERVAL` env var
- document new options in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6889f384e8ec83238aba217f581f8823