### PR TITLE
feat(codex): Add enemy detection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,11 @@ The Admin WebUI is exposed on port `8080` and can be accessed via a web browser.
 ### Deployment
 
 The Admin WebUI is included in the Helm chart for the `droneops-sim` project. Follow the steps in the [Deployment in Kubernetes](#deployment-in-kubernetes) section to deploy the simulator and access the Admin WebUI.
+
+## Enemy Detection
+
+The simulator now generates random enemy entities and emits detection events when drones are within range.
+
+- An **Enemy Simulation Engine** moves enemies around the first configured zone.
+- Drones check for nearby enemies every tick (1 km radius).
+- Detection events are written to the `enemy_detection` table when using GreptimeDB or printed to STDOUT in print-only mode.

--- a/internal/admin/server_test.go
+++ b/internal/admin/server_test.go
@@ -16,7 +16,7 @@ func TestHandleToggleChaos(t *testing.T) {
 		Zones:  []config.Region{{Name: "region-1", CenterLat: 48.2, CenterLon: 16.4, RadiusKM: 50}},
 		Fleets: []config.Fleet{{Name: "fleet-1", Model: "small-fpv", Count: 3}},
 	}
-	sim := sim.NewSimulator("test-cluster", cfg, nil, 1)
+	sim := sim.NewSimulator("test-cluster", cfg, nil, nil, 1)
 	server := NewServer(sim)
 
 	// Create a request to toggle chaos
@@ -53,7 +53,7 @@ func TestHandleLaunchDrones(t *testing.T) {
 		Zones:  []config.Region{{Name: "region-1", CenterLat: 48.2, CenterLon: 16.4, RadiusKM: 50}},
 		Fleets: []config.Fleet{{Name: "fleet-1", Model: "small-fpv", Count: 3}},
 	}
-	sim := sim.NewSimulator("test-cluster", cfg, nil, 1)
+	sim := sim.NewSimulator("test-cluster", cfg, nil, nil, 1)
 	server := NewServer(sim)
 
 	// Create a request to launch drones
@@ -89,7 +89,7 @@ func TestHandleHealth(t *testing.T) {
 		Zones:  []config.Region{{Name: "region-1", CenterLat: 48.2, CenterLon: 16.4, RadiusKM: 50}},
 		Fleets: []config.Fleet{{Name: "fleet-1", Model: "small-fpv", Count: 1}},
 	}
-	simulator := sim.NewSimulator("cluster", cfg, nil, 1)
+	simulator := sim.NewSimulator("cluster", cfg, nil, nil, 1)
 	server := NewServer(simulator)
 
 	req := httptest.NewRequest(http.MethodGet, "/fleet-health", nil)

--- a/internal/enemy/engine.go
+++ b/internal/enemy/engine.go
@@ -1,0 +1,59 @@
+package enemy
+
+import (
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/google/uuid"
+
+	"droneops-sim/internal/telemetry"
+)
+
+// Engine maintains and updates simulated enemy entities.
+type Engine struct {
+	region  telemetry.Region
+	Enemies []*Enemy
+}
+
+// NewEngine creates an engine with a given number of enemies in the region.
+func NewEngine(count int, region telemetry.Region) *Engine {
+	e := &Engine{region: region}
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < count; i++ {
+		en := &Enemy{
+			ID:         uuid.New().String(),
+			Type:       randomType(),
+			Position:   randomPosition(region),
+			Confidence: 100,
+		}
+		e.Enemies = append(e.Enemies, en)
+	}
+	return e
+}
+
+func randomType() EnemyType {
+	types := []EnemyType{EnemyVehicle, EnemyPerson, EnemyDrone}
+	return types[rand.Intn(len(types))]
+}
+
+func randomPosition(region telemetry.Region) telemetry.Position {
+	angle := rand.Float64() * 2 * math.Pi
+	r := rand.Float64() * region.RadiusKM * 1000
+	dLat := (r * math.Cos(angle)) / 111000
+	dLon := (r * math.Sin(angle)) / (111000 * math.Cos(region.CenterLat*math.Pi/180))
+	return telemetry.Position{Lat: region.CenterLat + dLat, Lon: region.CenterLon + dLon, Alt: 0}
+}
+
+func randomStep(pos telemetry.Position) telemetry.Position {
+	dLat := rand.Float64()*0.001 - 0.0005
+	dLon := rand.Float64()*0.001 - 0.0005
+	return telemetry.Position{Lat: pos.Lat + dLat, Lon: pos.Lon + dLon, Alt: pos.Alt}
+}
+
+// Step moves all enemies slightly using a random walk.
+func (e *Engine) Step() {
+	for _, en := range e.Enemies {
+		en.Position = randomStep(en.Position)
+	}
+}

--- a/internal/enemy/types.go
+++ b/internal/enemy/types.go
@@ -1,0 +1,37 @@
+package enemy
+
+import (
+	"time"
+
+	"droneops-sim/internal/telemetry"
+)
+
+// EnemyType represents the type of enemy object.
+type EnemyType string
+
+const (
+	EnemyVehicle EnemyType = "vehicle"
+	EnemyPerson  EnemyType = "person"
+	EnemyDrone   EnemyType = "drone"
+)
+
+// Enemy represents one simulated enemy entity.
+type Enemy struct {
+	ID         string
+	Type       EnemyType
+	Position   telemetry.Position
+	Confidence float64
+}
+
+// DetectionRow describes a drone enemy detection event.
+type DetectionRow struct {
+	ClusterID  string    `json:"cluster_id"`
+	DroneID    string    `json:"drone_id"`
+	EnemyID    string    `json:"enemy_id"`
+	EnemyType  EnemyType `json:"enemy_type"`
+	Lat        float64   `json:"lat"`
+	Lon        float64   `json:"lon"`
+	Alt        float64   `json:"alt"`
+	Confidence float64   `json:"confidence"`
+	Timestamp  time.Time `json:"ts"`
+}

--- a/internal/sim/greptime_writer.go
+++ b/internal/sim/greptime_writer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	"droneops-sim/internal/enemy"
 	"droneops-sim/internal/telemetry"
 
 	greptime "github.com/GreptimeTeam/greptimedb-ingester-go"
@@ -13,13 +14,14 @@ import (
 
 // GreptimeDBWriter writes telemetry to GreptimeDB via the ingester client
 type GreptimeDBWriter struct {
-	client *greptime.Client
-	db     string
-	table  string
+	client         *greptime.Client
+	db             string
+	table          string
+	detectionTable string
 }
 
 // NewGreptimeDBWriter creates a new GreptimeDB writer.
-func NewGreptimeDBWriter(endpoint, database, table string) (*GreptimeDBWriter, error) {
+func NewGreptimeDBWriter(endpoint, database, table string, detectionTable string) (*GreptimeDBWriter, error) {
 	cfg := greptime.NewConfig(endpoint).
 		WithPort(4001).
 		WithDatabase(database)
@@ -33,11 +35,15 @@ func NewGreptimeDBWriter(endpoint, database, table string) (*GreptimeDBWriter, e
 	if table == "" {
 		table = telemetry.TelemetryTableName
 	}
+	if detectionTable == "" {
+		detectionTable = "enemy_detection"
+	}
 
 	return &GreptimeDBWriter{
-		client: client,
-		db:     database,
-		table:  table,
+		client:         client,
+		db:             database,
+		table:          table,
+		detectionTable: detectionTable,
 	}, nil
 }
 
@@ -96,5 +102,59 @@ func (w *GreptimeDBWriter) WriteBatch(rows []telemetry.TelemetryRow) error {
 	}
 
 	log.Printf("[GreptimeDBWriter] wrote %d rows", len(rows))
+	return nil
+}
+
+// WriteDetection inserts a single enemy detection row.
+func (w *GreptimeDBWriter) WriteDetection(d enemy.DetectionRow) error {
+	return w.WriteDetections([]enemy.DetectionRow{d})
+}
+
+// WriteDetections inserts multiple enemy detection rows.
+func (w *GreptimeDBWriter) WriteDetections(rows []enemy.DetectionRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	ctx := context.Background()
+
+	tbl, err := table.New(w.detectionTable)
+	if err != nil {
+		return err
+	}
+	tbl.AddTagColumn("cluster_id", types.STRING)
+	tbl.AddTagColumn("drone_id", types.STRING)
+	tbl.AddTagColumn("enemy_id", types.STRING)
+	tbl.AddTagColumn("enemy_type", types.STRING)
+	tbl.AddFieldColumn("lat", types.FLOAT64)
+	tbl.AddFieldColumn("lon", types.FLOAT64)
+	tbl.AddFieldColumn("alt", types.FLOAT64)
+	tbl.AddFieldColumn("confidence", types.FLOAT64)
+	tbl.AddTimestampColumn("ts", types.TIMESTAMP_MILLISECOND)
+
+	for _, r := range rows {
+		err := tbl.AddRow(
+			r.ClusterID,
+			r.DroneID,
+			r.EnemyID,
+			string(r.EnemyType),
+			r.Lat,
+			r.Lon,
+			r.Alt,
+			r.Confidence,
+			r.Timestamp,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = w.client.Write(ctx, tbl)
+	if err != nil {
+		log.Printf("[GreptimeDBWriter] Detection write failed: %v", err)
+		return err
+	}
+
+	log.Printf("[GreptimeDBWriter] wrote %d enemy detections", len(rows))
 	return nil
 }

--- a/internal/sim/stdout_writer.go
+++ b/internal/sim/stdout_writer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"droneops-sim/internal/enemy"
 	"droneops-sim/internal/telemetry"
 )
 
@@ -22,6 +23,21 @@ func (w *StdoutWriter) Write(row telemetry.TelemetryRow) error {
 func (w *StdoutWriter) WriteBatch(rows []telemetry.TelemetryRow) error {
 	for _, r := range rows {
 		_ = w.Write(r)
+	}
+	return nil
+}
+
+// WriteDetection prints an enemy detection event to STDOUT.
+func (w *StdoutWriter) WriteDetection(d enemy.DetectionRow) error {
+	data, _ := json.Marshal(d)
+	fmt.Println(string(data))
+	return nil
+}
+
+// WriteDetections prints multiple enemy detections.
+func (w *StdoutWriter) WriteDetections(rows []enemy.DetectionRow) error {
+	for _, d := range rows {
+		_ = w.WriteDetection(d)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- introduce `enemy` package with simulation and detection row types
- extend `Simulator` to detect nearby enemy entities
- implement detection writers for stdout and GreptimeDB
- update admin tests and simulator tests
- describe the new feature in the README

## Testing
- `go test ./... -v`

------
https://chatgpt.com/codex/tasks/task_e_688b2930e8788323996c739cfcefa42b