### PR TITLE
Add enemy detection table env docs and helm config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ cue vet config/simulation.yaml schemas/simulation.cue
 
 - `GREPTIMEDB_ENDPOINT` → If set, telemetry is written to this GreptimeDB endpoint
 - `GREPTIMEDB_TABLE` → Target table for telemetry (default: drone_telemetry)
+- `ENEMY_DETECTION_TABLE` → Table for enemy detection events (default: enemy_detection)
 - `MISSION_METADATA_TABLE` → Table storing mission metadata (default: mission_metadata)
 - `CLUSTER_ID` → Cluster identity tag (default: mission-01)
 - `TICK_INTERVAL` → Telemetry tick interval in Go duration format (overrides `--tick`)
@@ -199,4 +200,4 @@ The simulator now generates random enemy entities and emits detection events whe
 
 - An **Enemy Simulation Engine** moves enemies around the first configured zone.
 - Drones check for nearby enemies every tick (1 km radius).
-- Detection events are written to the `enemy_detection` table when using GreptimeDB or printed to STDOUT in print-only mode.
+- Detection events are written to the table specified by `ENEMY_DETECTION_TABLE` (default `enemy_detection`) when using GreptimeDB or printed to STDOUT in print-only mode.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -41,6 +41,7 @@ To write to GreptimeDB instead, set the endpoint and table variables:
 ```bash
 export GREPTIMEDB_ENDPOINT=127.0.0.1:4001
 export GREPTIMEDB_TABLE=drone_telemetry
+export ENEMY_DETECTION_TABLE=enemy_detection
 ./build/droneops-sim
 ```
 

--- a/docs/helm-deployment.md
+++ b/docs/helm-deployment.md
@@ -47,7 +47,7 @@ The `droneops-sim` project includes a Helm chart for deploying the simulator in 
 
 - The Helm chart uses ConfigMaps to manage simulation and schema configurations.
 - Ensure the Kubernetes cluster has sufficient resources to handle the configured replicas and resource limits.
-- Update the `GREPTIMEDB_ENDPOINT` and `GREPTIMEDB_TABLE` environment variables in the deployment if connecting to a real database.
+- Update the `GREPTIMEDB_ENDPOINT`, `GREPTIMEDB_TABLE`, and `ENEMY_DETECTION_TABLE` environment variables in the deployment if connecting to a real database.
 
 For more details, refer to the `helm/droneops-sim` directory and the `values.yaml` file.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,6 +12,7 @@ make run
 ```bash
 export GREPTIMEDB_ENDPOINT=127.0.0.1:4001
 export GREPTIMEDB_TABLE=drone_telemetry
+export ENEMY_DETECTION_TABLE=enemy_detection
 ./build/droneops-sim
 ```
 
@@ -22,6 +23,7 @@ docker build -t droneops-sim:latest .
 docker run --rm \
     -e GREPTIMEDB_ENDPOINT=127.0.0.1:4001 \
     -e GREPTIMEDB_TABLE=drone_telemetry \
+    -e ENEMY_DETECTION_TABLE=enemy_detection \
     droneops-sim:latest
 ```
 

--- a/helm/droneops-sim/templates/deployment.yaml
+++ b/helm/droneops-sim/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
           value: "127.0.0.1:4001"
         - name: GREPTIMEDB_TABLE
           value: "drone_telemetry"
+        - name: ENEMY_DETECTION_TABLE
+          value: "enemy_detection"
         - name: CLUSTER_ID
           value: "mission-01"
         volumeMounts:


### PR DESCRIPTION
## Summary
- document `ENEMY_DETECTION_TABLE` env var
- include example usage in docs
- update helm deployment with the new variable

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688b81f18af483239d3079549d423d8a