### PR TITLE
feat(codex): add 3d map visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The Admin WebUI provides a centralized interface for monitoring and managing dro
 - **Chaos Mode Toggle**: Allows users to enable or disable chaos mode, simulating random failures and unpredictable behavior.
 - **Drone Launch Control**: Provides an interface to launch drones for specific missions or operations.
 - **Mission Visualization**: Shows mission objectives, regions, and associated drones.
+- **3D Map Option**: View drone positions on a CesiumJS-based map at `/3d`.
 - **Interactive Command Console**: Enables direct interaction with the simulator for advanced operations.
 
 ### Access

--- a/internal/admin/templates/map3d.html
+++ b/internal/admin/templates/map3d.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>DroneOps 3D Map</title>
+<style>body,html{margin:0;padding:0;height:100%;overflow:hidden;}#cesiumContainer{width:100%;height:100%;display:block;}</style>
+<link href="https://unpkg.com/cesium@1.110.1/Build/Cesium/Widgets/widgets.css" rel="stylesheet">
+<script src="https://unpkg.com/cesium@1.110.1/Build/Cesium/Cesium.js"></script>
+</head>
+<body>
+<div id="cesiumContainer"></div>
+<script>
+const viewer = new Cesium.Viewer('cesiumContainer');
+async function load(){
+  const res = await fetch('/telemetry');
+  const data = await res.json();
+  viewer.entities.removeAll();
+  data.forEach(d => {
+    viewer.entities.add({
+      position: Cesium.Cartesian3.fromDegrees(d.lon, d.lat, d.alt),
+      point: { pixelSize: 6, color: Cesium.Color.CYAN },
+      label: { text: d.drone_id, pixelOffset: new Cesium.Cartesian2(0, -20) }
+    });
+  });
+}
+setInterval(load, 1000);
+load();
+</script>
+</body>
+</html>

--- a/internal/sim/simulator.go
+++ b/internal/sim/simulator.go
@@ -201,6 +201,28 @@ func (s *Simulator) GetConfig() *config.SimulationConfig {
 	return s.cfg
 }
 
+// TelemetrySnapshot returns the latest state for all drones.
+func (s *Simulator) TelemetrySnapshot() []telemetry.TelemetryRow {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var rows []telemetry.TelemetryRow
+	for _, fleet := range s.fleets {
+		for _, drone := range fleet.Drones {
+			rows = append(rows, telemetry.TelemetryRow{
+				ClusterID: s.clusterID,
+				DroneID:   drone.ID,
+				Lat:       drone.Position.Lat,
+				Lon:       drone.Position.Lon,
+				Alt:       drone.Position.Alt,
+				Battery:   drone.Battery,
+				Status:    drone.Status,
+				Timestamp: time.Now().UTC(),
+			})
+		}
+	}
+	return rows
+}
+
 func generateDroneID(fleetName string, index int) string {
 	// Include the drone's index along with a UUID to guarantee uniqueness
 	id := uuid.New().String()


### PR DESCRIPTION
## Summary
- expose `/3d` and `/telemetry` endpoints in Admin UI
- provide a CesiumJS-based 3D map template
- add `TelemetrySnapshot` API for simulator
- document 3D map option
- test new telemetry endpoint

## Testing
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688a446aa344832396c11813f699528a