### PR TITLE
tests(codex): Add Swarm Response tests

### DIFF
--- a/internal/admin/server_test.go
+++ b/internal/admin/server_test.go
@@ -115,7 +115,7 @@ func TestHandleTelemetry(t *testing.T) {
 		Zones:  []config.Region{{Name: "r1", CenterLat: 0, CenterLon: 0, RadiusKM: 1}},
 		Fleets: []config.Fleet{{Name: "f1", Model: "small-fpv", Count: 1}},
 	}
-	sim := sim.NewSimulator("cluster", cfg, nil, 1)
+	sim := sim.NewSimulator("cluster", cfg, nil, nil, 1)
 	server := NewServer(sim)
 
 	req := httptest.NewRequest(http.MethodGet, "/telemetry", nil)


### PR DESCRIPTION
## Summary
- fix simulator init in server tests
- add unit tests for Swarm Response follow behaviour

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cb8390a288323a62c5104b869aec6