### PR TITLE
feat(codex): Enhance 3D view with enemy & swarm data

### DIFF
--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -29,6 +29,7 @@ func NewServer(sim *sim.Simulator) *Server {
 func (s *Server) routes() {
 	http.HandleFunc("/", s.handleIndex)
 	http.HandleFunc("/3d", s.handle3D)
+	http.HandleFunc("/map-data", s.handleMapData)
 	http.HandleFunc("/telemetry", s.handleTelemetry)
 	http.HandleFunc("/toggle-chaos", s.handleToggleChaos)
 	http.HandleFunc("/launch-drones", s.handleLaunch)
@@ -85,4 +86,9 @@ func (s *Server) handle3D(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleTelemetry(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(s.Sim.TelemetrySnapshot())
+}
+
+func (s *Server) handleMapData(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(s.Sim.MapSnapshot())
 }

--- a/internal/admin/templates/map3d.html
+++ b/internal/admin/templates/map3d.html
@@ -12,15 +12,37 @@
 <script>
 const viewer = new Cesium.Viewer('cesiumContainer');
 async function load(){
-  const res = await fetch('/telemetry');
+  const res = await fetch('/map-data');
   const data = await res.json();
   viewer.entities.removeAll();
-  data.forEach(d => {
+
+  data.enemies.forEach(e => {
+    viewer.entities.add({
+      position: Cesium.Cartesian3.fromDegrees(e.lon, e.lat, e.alt),
+      point: { pixelSize: 8, color: Cesium.Color.RED },
+      label: { text: e.type, pixelOffset: new Cesium.Cartesian2(0, 20) }
+    });
+  });
+
+  data.drones.forEach(d => {
     viewer.entities.add({
       position: Cesium.Cartesian3.fromDegrees(d.lon, d.lat, d.alt),
       point: { pixelSize: 6, color: Cesium.Color.CYAN },
-      label: { text: d.drone_id, pixelOffset: new Cesium.Cartesian2(0, -20) }
+      label: { text: d.id, pixelOffset: new Cesium.Cartesian2(0, -20) },
+      description: `Battery: ${d.battery.toFixed(1)}%`
     });
+    if(d.follow_lat !== undefined){
+      viewer.entities.add({
+        polyline: {
+          positions: Cesium.Cartesian3.fromDegreesArrayHeights([
+            d.lon, d.lat, d.alt,
+            d.follow_lon, d.follow_lat, d.follow_alt
+          ]),
+          width: 2,
+          material: Cesium.Color.YELLOW
+        }
+      });
+    }
   });
 }
 setInterval(load, 1000);


### PR DESCRIPTION
## Summary
- expose `/map-data` API for combined drone & enemy positions
- send map data from `Simulator.MapSnapshot`
- visualise drones, enemies, and follow lines on the Cesium map
- test new endpoint

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688cbe39d11c8323b3b809d49454b267