### PR TITLE
feat(enemy): add dynamic enemy behavior and multi-zone spawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The Admin WebUI is included in the Helm chart for the `droneops-sim` project. Fo
 
 The simulator includes an enemy detection subsystem used to test how drones react to hostile objects.
 
-- An **Enemy Simulation Engine** spawns a configurable number of enemies in the first configured zone and moves them each tick using a random walk.
+- An **Enemy Simulation Engine** spawns a configurable number of enemies across all configured zones and updates them each tick. Enemies react to nearby drones with evasive maneuvers, may group together, or deploy decoys.
 - Every drone checks for enemies within a configurable detection radius (default: 1&nbsp;km) each tick. Confidence is influenced by distance as well as sensor noise, terrain occlusion and weather conditions.
 - Detection events are written to the table specified by `ENEMY_DETECTION_TABLE` when writing to GreptimeDB, or printed to STDOUT in print-only mode.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,7 +97,7 @@ swarm_responses:
 `follow_confidence` sets the detection confidence threshold required for a drone
 to switch into follow mode.
 
-`enemy_count` controls how many hostile entities are simulated in the first zone and `detection_radius_m` sets the detection range in meters for each drone. `sensor_noise`, `terrain_occlusion`, and `weather_impact` modify detection confidence to account for sensor errors and environmental effects.
+`enemy_count` controls how many hostile entities are simulated in each zone and `detection_radius_m` sets the detection range in meters for each drone. `sensor_noise`, `terrain_occlusion`, and `weather_impact` modify detection confidence to account for sensor errors and environmental effects.
 
 ### Enemy Detection
 

--- a/docs/enemy-detection.md
+++ b/docs/enemy-detection.md
@@ -5,13 +5,14 @@ This feature simulates hostile objects ("enemies") and reports when drones spot 
 ## Purpose
 
 Enemy detections allow you to test how your monitoring stack reacts to potential threats. The simulator
-randomly moves a few enemy entities around the first configured zone and emits a detection event whenever
-a drone is within range.
+spawns enemy entities across all configured zones and makes them react to nearby drones using evasive,
+grouping, and decoy tactics. A detection event is emitted whenever a drone is within range.
 
 ## How It Works
 
-1. On startup the simulator creates `enemy_count` enemies inside the first zone defined in `config/simulation.yaml` (default: 3).
-2. Each tick the enemies take a small random step within that zone.
+1. On startup the simulator creates `enemy_count` enemies in **each** zone defined in `config/simulation.yaml` (default: 3).
+2. Each tick the enemies update their position. When drones are nearby they attempt evasive maneuvers,
+   may group with other enemies, or spawn decoys to distract pursuers.
 3. Every drone checks for enemies within the configured `detection_radius_m` (default: **1000&nbsp;m**). When an enemy is detected an event is generated with a
    confidence value that decreases with distance and is further modified by sensor noise, terrain occlusion and weather impact.
 4. Detection events are either printed to STDOUT (print-only mode) or inserted into GreptimeDB.
@@ -31,7 +32,7 @@ The following fields in `config/simulation.yaml` control the enemy detection beh
 
 | Field               | Description                                      | Default |
 |---------------------|--------------------------------------------------|---------|
-| `enemy_count`       | Number of simulated enemies in the zone          | `3`     |
+| `enemy_count`       | Number of simulated enemies per zone             | `3`     |
 | `detection_radius_m`| Radius in meters for enemy detection checks      | `1000`  |
 | `sensor_noise`      | Standard deviation of sensor noise (fraction)    | `0`     |
 | `terrain_occlusion` | Terrain occlusion factor (0-1)                   | `0`     |

--- a/internal/enemy/engine_test.go
+++ b/internal/enemy/engine_test.go
@@ -1,0 +1,56 @@
+package enemy
+
+import (
+	"testing"
+
+	"math/rand"
+
+	"droneops-sim/internal/telemetry"
+)
+
+func TestEngine_EvasiveManeuver(t *testing.T) {
+	eng := &Engine{regions: []telemetry.Region{{CenterLat: 0, CenterLon: 0, RadiusKM: 1}}, Enemies: []*Enemy{{ID: "e", Type: EnemyVehicle, Position: telemetry.Position{Lat: 0, Lon: 0}, Confidence: 100, Region: telemetry.Region{CenterLat: 0, CenterLon: 0, RadiusKM: 1}}}}
+	drone := &telemetry.Drone{Position: telemetry.Position{Lat: 0, Lon: 0}}
+	rand.Seed(1) // avoid decoy spawn
+	eng.Step([]*telemetry.Drone{drone})
+	if distance(eng.Enemies[0].Position, drone.Position) == 0 {
+		t.Fatalf("expected enemy to move away from drone")
+	}
+}
+
+func TestEngine_SpawnMultipleRegions(t *testing.T) {
+	regions := []telemetry.Region{{CenterLat: 0, CenterLon: 0, RadiusKM: 1}, {CenterLat: 1, CenterLon: 1, RadiusKM: 1}}
+	eng := NewEngine(1, regions)
+	if len(eng.Enemies) != 2 {
+		t.Fatalf("expected 2 enemies, got %d", len(eng.Enemies))
+	}
+	foundA, foundB := false, false
+	for _, e := range eng.Enemies {
+		if distance(e.Position, telemetry.Position{Lat: regions[0].CenterLat, Lon: regions[0].CenterLon}) < regions[0].RadiusKM/111 {
+			foundA = true
+		}
+		if distance(e.Position, telemetry.Position{Lat: regions[1].CenterLat, Lon: regions[1].CenterLon}) < regions[1].RadiusKM/111 {
+			foundB = true
+		}
+	}
+	if !foundA || !foundB {
+		t.Fatalf("enemies not spawned in all regions")
+	}
+}
+
+func TestEngine_SpawnDecoy(t *testing.T) {
+	eng := &Engine{regions: []telemetry.Region{{CenterLat: 0, CenterLon: 0, RadiusKM: 1}}, Enemies: []*Enemy{{ID: "e", Type: EnemyVehicle, Position: telemetry.Position{Lat: 0, Lon: 0}, Confidence: 100, Region: telemetry.Region{CenterLat: 0, CenterLon: 0, RadiusKM: 1}}}}
+	drone := &telemetry.Drone{Position: telemetry.Position{Lat: 0, Lon: 0}}
+	for i := 0; i < 100; i++ {
+		eng.Enemies[0].Position = telemetry.Position{Lat: 0, Lon: 0}
+		eng.Step([]*telemetry.Drone{drone})
+		if len(eng.Enemies) > 1 {
+			decoy := eng.Enemies[1]
+			if decoy.Type != EnemyDecoy {
+				t.Fatalf("expected decoy type, got %s", decoy.Type)
+			}
+			return
+		}
+	}
+	t.Fatalf("expected decoy to spawn")
+}

--- a/internal/enemy/types.go
+++ b/internal/enemy/types.go
@@ -13,6 +13,7 @@ const (
 	EnemyVehicle EnemyType = "vehicle"
 	EnemyPerson  EnemyType = "person"
 	EnemyDrone   EnemyType = "drone"
+	EnemyDecoy   EnemyType = "decoy"
 )
 
 // Enemy represents one simulated enemy entity.
@@ -21,6 +22,7 @@ type Enemy struct {
 	Type       EnemyType
 	Position   telemetry.Position
 	Confidence float64
+	Region     telemetry.Region
 }
 
 // DetectionRow describes a drone enemy detection event.

--- a/internal/sim/simulator_test.go
+++ b/internal/sim/simulator_test.go
@@ -231,7 +231,7 @@ func TestSimulator_CustomDetectionRadius(t *testing.T) {
 	sim := NewSimulator("cluster", cfg, writer, dWriter, time.Second)
 
 	drone := sim.fleets[0].Drones[0]
-	sim.enemyEng.Enemies = []*enemy.Enemy{{ID: "e", Type: enemy.EnemyVehicle, Position: telemetry.Position{Lat: drone.Position.Lat + 0.004, Lon: drone.Position.Lon, Alt: 0}}}
+	sim.enemyEng.Enemies = []*enemy.Enemy{{ID: "e", Type: enemy.EnemyVehicle, Position: telemetry.Position{Lat: drone.Position.Lat + 0.002, Lon: drone.Position.Lon, Alt: 0}}}
 
 	sim.tick()
 


### PR DESCRIPTION
## Summary
- add enemy engine that spawns per zone and reacts with evasive, grouping, and decoy tactics
- pass drone positions to enemy engine and distribute enemies across configured zones
- document dynamic enemy behaviour and cover tactics with unit tests

## Testing
- `go vet ./...`
- `cue vet config/simulation.yaml schemas/simulation.cue` *(fails: command not found)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688df55676b08323ac42c5c42a99664b