### PR TITLE
docs: summarize environment variables for easier onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,16 @@ cue vet config/simulation.yaml schemas/simulation.cue
 
 ### Environment Variables
 
-- `GREPTIMEDB_ENDPOINT` → If set, telemetry is written to this GreptimeDB endpoint
-- `GREPTIMEDB_TABLE` → Target table for telemetry (default: drone_telemetry)
-- `ENEMY_DETECTION_TABLE` → Table for enemy detection events (default: enemy_detection)
-- `MISSION_METADATA_TABLE` → Table storing mission metadata (default: mission_metadata)
-- `ENEMY_DETECTION_TABLE` → Table storing enemy detection events (default: enemy_detection)
-- `CLUSTER_ID` → Cluster identity tag (default: mission-01)
-- `TICK_INTERVAL` → Telemetry tick interval in Go duration format (overrides `--tick`)
+The simulator can be configured through the following environment variables:
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `GREPTIMEDB_ENDPOINT` | _none_ | Yes (for GreptimeDB) | GreptimeDB gRPC endpoint. If unset, telemetry is printed to STDOUT. |
+| `GREPTIMEDB_TABLE` | `drone_telemetry` | No | Table for drone telemetry records. |
+| `ENEMY_DETECTION_TABLE` | `enemy_detection` | No | Table storing enemy detection events. |
+| `MISSION_METADATA_TABLE` | `mission_metadata` | No | Table storing mission metadata. |
+| `CLUSTER_ID` | `mission-01` | No | Cluster identity tag added to each telemetry line. |
+| `TICK_INTERVAL` | `1s` | No | Telemetry tick interval (Go duration). Overrides the `--tick` flag. |
 
 ## Quickstart
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,7 @@
 ## Quickstart
 
+Refer to the [Environment Variables](../README.md#environment-variables) table for more configuration options.
+
 ### Local Demo (Print Only)
 
 ```bash


### PR DESCRIPTION
## Summary
- present environment variables in a table with defaults and requirements
- cross-link quickstart to the environment variables table

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688dfd0b9b0083239f36ec46c84b2978