### PR TITLE
feat: add predictive interception for swarms

### DIFF
--- a/docs/swarm-response.md
+++ b/docs/swarm-response.md
@@ -16,6 +16,10 @@ The simulator adjusts the follower count when:
 
 Configure the base mapping under `swarm_responses` and the mission importance with `mission_criticality` in `config/simulation.yaml`.
 
+## Predictive Interception
+
+When several drones pursue a moving enemy, they no longer trail the target. Instead, the simulator predicts the enemy's path and assigns intercept and flanking points so the swarm can cut off escape routes cooperatively.
+
 ## Formation Reconfiguration
 
 When drones peel off to pursue a target, the remaining units automatically reposition around the home region. This reconfiguration keeps surveillance coverage balanced by assigning new patrol points to the drones still in formation.


### PR DESCRIPTION
## Summary
- track previous enemy positions to enable predictive interception
- assign flanking intercept points for swarm followers
- document cooperative interception behavior and add tests

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688e010186488323a9c1dc3689386977