### PR TITLE
feat: add scenario DSL for mission phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It supports:
 - **Battery drain and failure simulation**
 - **Configurable sensor errors, communication dropouts, and battery anomalies**
 - **Output to GreptimeDB** using its gRPC ORM interface **or** to STDOUT for quick demos
+- **Mission scenarios** scripted with a lightweight DSL for phases and enemy objectives
 
 This project was designed to support visualization dashboards (e.g., Grafana Geomap panel) and multi-cluster sync scenarios (mission clusters → command cluster).
 
@@ -32,6 +33,7 @@ For development and contribution guidelines, see [docs/CONTRIBUTING.md](docs/CON
 
 Detailed configuration options are documented in [docs/configuration.md](docs/configuration.md).
 See [docs/swarm-response.md](docs/swarm-response.md) for how drone swarms react to enemy detections.
+Scenarios can be authored using the [Scenario DSL](docs/scenario.md) to drive mission phases and triggers.
 
 ## Schema Validation (schemas/simulation.cue)
 

--- a/config/scenario.yaml
+++ b/config/scenario.yaml
@@ -1,0 +1,26 @@
+# Example scenario definition for the simulator
+phases:
+  - name: patrol
+    description: initial area security
+    enemy_objectives:
+      - id: enemy-1
+        action: patrol
+    triggers:
+      - event: time_elapsed
+        value: 60
+        next: intercept
+  - name: intercept
+    description: aggressive move toward base
+    enemy_objectives:
+      - id: enemy-1
+        action: attack
+        target: base
+    triggers:
+      - event: enemy_destroyed
+        value: 1
+        next: retreat
+  - name: retreat
+    description: enemy forces withdraw
+    enemy_objectives:
+      - id: enemy-1
+        action: retreat

--- a/docs/scenario.md
+++ b/docs/scenario.md
@@ -1,0 +1,51 @@
+# Scenario DSL
+
+The simulator can script high-level mission flows using a lightweight YAML-based domain specific language (DSL).
+A scenario defines ordered **phases**, the **triggers** that move the mission between phases and the **enemy objectives** active in each phase.
+
+## Example
+
+```yaml
+phases:
+  - name: patrol
+    enemy_objectives:
+      - id: enemy-1
+        action: patrol
+    triggers:
+      - event: time_elapsed
+        value: 60
+        next: intercept
+  - name: intercept
+    enemy_objectives:
+      - id: enemy-1
+        action: attack
+        target: base
+    triggers:
+      - event: enemy_destroyed
+        value: 1
+        next: retreat
+  - name: retreat
+    enemy_objectives:
+      - id: enemy-1
+        action: retreat
+```
+
+* `event` describes what to wait for (`time_elapsed`, `enemy_destroyed`, etc.).
+* `value` provides the threshold (seconds or count).
+* `next` is the phase to transition to once the trigger condition is met.
+
+## Loading
+
+The scenario can be loaded at runtime using the `scenario` package:
+
+```go
+sc, err := scenario.Load("config/scenario.yaml")
+```
+
+Transitions are evaluated with `NextPhase`:
+
+```go
+next, ok := sc.NextPhase("patrol", scenario.Event{Type: "time_elapsed", Value: 60})
+```
+
+This DSL is intentionally simple and designed to be extended with additional trigger or objective types as the simulator evolves.

--- a/internal/scenario/scenario.go
+++ b/internal/scenario/scenario.go
@@ -1,0 +1,70 @@
+package scenario
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Scenario defines a mission scenario with ordered phases.
+type Scenario struct {
+	Phases []Phase `yaml:"phases"`
+}
+
+// Phase describes a stage in the mission with objectives and triggers for transitions.
+type Phase struct {
+	Name            string           `yaml:"name"`
+	Description     string           `yaml:"description,omitempty"`
+	EnemyObjectives []EnemyObjective `yaml:"enemy_objectives,omitempty"`
+	Triggers        []Trigger        `yaml:"triggers,omitempty"`
+}
+
+// EnemyObjective declares a dynamic behaviour for an enemy entity during a phase.
+type EnemyObjective struct {
+	ID     string `yaml:"id"`
+	Action string `yaml:"action"`
+	Target string `yaml:"target,omitempty"`
+}
+
+// Trigger moves the scenario to another phase based on an event.
+type Trigger struct {
+	Event string `yaml:"event"`
+	Value int    `yaml:"value"`
+	Next  string `yaml:"next"`
+}
+
+// Event represents a runtime occurrence that may advance the scenario.
+type Event struct {
+	Type  string
+	Value int
+}
+
+// Load reads a YAML scenario definition from disk.
+func Load(path string) (*Scenario, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read scenario: %w", err)
+	}
+	var s Scenario
+	if err := yaml.Unmarshal(b, &s); err != nil {
+		return nil, fmt.Errorf("parse scenario: %w", err)
+	}
+	return &s, nil
+}
+
+// NextPhase returns the name of the next phase given the current phase and event.
+// If no trigger matches, ok will be false.
+func (s *Scenario) NextPhase(current string, ev Event) (next string, ok bool) {
+	for _, p := range s.Phases {
+		if p.Name != current {
+			continue
+		}
+		for _, tr := range p.Triggers {
+			if tr.Event == ev.Type && ev.Value >= tr.Value {
+				return tr.Next, true
+			}
+		}
+	}
+	return "", false
+}

--- a/internal/scenario/scenario_test.go
+++ b/internal/scenario/scenario_test.go
@@ -1,0 +1,32 @@
+package scenario
+
+import "testing"
+
+func TestScenarioTransition(t *testing.T) {
+	s := Scenario{
+		Phases: []Phase{{
+			Name:     "patrol",
+			Triggers: []Trigger{{Event: "time_elapsed", Value: 10, Next: "attack"}},
+		}, {
+			Name: "attack",
+		}},
+	}
+
+	next, ok := s.NextPhase("patrol", Event{Type: "time_elapsed", Value: 10})
+	if !ok || next != "attack" {
+		t.Fatalf("expected transition to attack, got %s", next)
+	}
+}
+
+func TestLoadScenario(t *testing.T) {
+	sc, err := Load("testdata/simple.yaml")
+	if err != nil {
+		t.Fatalf("load scenario: %v", err)
+	}
+	if len(sc.Phases) != 2 {
+		t.Fatalf("expected 2 phases, got %d", len(sc.Phases))
+	}
+	if sc.Phases[0].EnemyObjectives[0].Action != "patrol" {
+		t.Fatalf("unexpected objective action %s", sc.Phases[0].EnemyObjectives[0].Action)
+	}
+}

--- a/internal/scenario/testdata/simple.yaml
+++ b/internal/scenario/testdata/simple.yaml
@@ -1,0 +1,14 @@
+phases:
+  - name: patrol
+    enemy_objectives:
+      - id: e1
+        action: patrol
+    triggers:
+      - event: time_elapsed
+        value: 30
+        next: attack
+  - name: attack
+    enemy_objectives:
+      - id: e1
+        action: attack
+        target: base


### PR DESCRIPTION
## Summary
- add scenario package providing YAML-based DSL for mission phases, triggers and enemy objectives
- include sample scenario config and documentation
- update README to reference scenario scripting

## Testing
- `go vet ./...`
- `make test`
- `cue vet config/simulation.yaml schemas/simulation.cue` *(fails: missions.0.zone: incomplete value string)*

------
https://chatgpt.com/codex/tasks/task_e_688e3fd12c6483238d0292b391c8d25b