### PR TITLE
feat: add built-in story arcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ For development and contribution guidelines, see [docs/CONTRIBUTING.md](docs/CON
 Detailed configuration options are documented in [docs/configuration.md](docs/configuration.md).
 See [docs/swarm-response.md](docs/swarm-response.md) for how drone swarms react to enemy detections.
 Scenarios can be authored using the [Scenario DSL](docs/scenario.md) to drive mission phases and triggers.
+Common narrative patterns such as escort and search-and-rescue are available as built-in [story arcs](docs/story-arcs.md).
 
 ## Schema Validation (schemas/simulation.cue)
 

--- a/config/scenario_defensive_stand.yaml
+++ b/config/scenario_defensive_stand.yaml
@@ -1,0 +1,31 @@
+name: defensive-stand
+description: Hold a critical relay station against waves of hostile drones.
+phases:
+  - name: setup
+    description: Defenders fortify the station and establish fields of fire.
+    triggers:
+      - event: time_elapsed
+        value: 30
+        next: escalation
+  - name: escalation
+    description: The first wave tests the defenses.
+    enemy_objectives:
+      - id: wave1
+        action: attack
+        target: station
+    triggers:
+      - event: enemy_destroyed
+        value: 5
+        next: climax
+  - name: climax
+    description: A massive assault threatens to overwhelm the defenders.
+    enemy_objectives:
+      - id: wave2
+        action: attack
+        target: station
+    triggers:
+      - event: time_elapsed
+        value: 120
+        next: resolution
+  - name: resolution
+    description: Enemy forces withdraw and the station remains secure.

--- a/config/scenario_escort.yaml
+++ b/config/scenario_escort.yaml
@@ -1,0 +1,31 @@
+name: escort
+description: Protect a vulnerable convoy as it travels to the forward operating base.
+phases:
+  - name: setup
+    description: Convoy forms up and prepares to depart.
+    triggers:
+      - event: time_elapsed
+        value: 30
+        next: escalation
+  - name: escalation
+    description: Light enemy forces probe the escort.
+    enemy_objectives:
+      - id: bandits
+        action: harass
+        target: convoy
+    triggers:
+      - event: enemy_destroyed
+        value: 3
+        next: climax
+  - name: climax
+    description: A coordinated ambush hits the convoy near a choke point.
+    enemy_objectives:
+      - id: ambush
+        action: attack
+        target: convoy
+    triggers:
+      - event: enemy_destroyed
+        value: 5
+        next: resolution
+  - name: resolution
+    description: Remaining threats fall back as the convoy reaches safety.

--- a/config/scenario_search_and_rescue.yaml
+++ b/config/scenario_search_and_rescue.yaml
@@ -1,0 +1,27 @@
+name: search-and-rescue
+description: Locate and recover a downed pilot before hostile forces arrive.
+phases:
+  - name: setup
+    description: Rescue team briefs and launches into the search area.
+    triggers:
+      - event: time_elapsed
+        value: 20
+        next: escalation
+  - name: escalation
+    description: Search intensifies as signs of the pilot are found.
+    triggers:
+      - event: survivor_found
+        value: 1
+        next: climax
+  - name: climax
+    description: Enemy patrols close in while the extraction is attempted.
+    enemy_objectives:
+      - id: enemy-patrol
+        action: attack
+        target: rescue-team
+    triggers:
+      - event: survivor_extracted
+        value: 1
+        next: resolution
+  - name: resolution
+    description: Team departs the area with the survivor; remaining enemies retreat.

--- a/docs/story-arcs.md
+++ b/docs/story-arcs.md
@@ -1,0 +1,15 @@
+# Built-in Story Arcs
+
+The simulator includes predefined mission patterns to accelerate scenario design. Each arc follows the classic narrative flow of **setup**, **escalation**, **climax**, and **resolution**. The YAML files in `config/` provide ready-to-use examples.
+
+## Escort
+- **Mission**: Protect a vulnerable convoy as it travels to the forward operating base.
+- **Sample**: `config/scenario_escort.yaml`
+
+## Search and Rescue
+- **Mission**: Locate and recover a downed pilot before hostile forces arrive.
+- **Sample**: `config/scenario_search_and_rescue.yaml`
+
+## Defensive Stand
+- **Mission**: Hold a critical relay station against waves of hostile drones.
+- **Sample**: `config/scenario_defensive_stand.yaml`

--- a/internal/scenario/arcs.go
+++ b/internal/scenario/arcs.go
@@ -1,0 +1,87 @@
+package scenario
+
+// BuiltIn returns predefined story arcs with mission descriptions.
+func BuiltIn() map[string]Scenario {
+	return map[string]Scenario{
+		"escort": {
+			Name:        "Escort",
+			Description: "Protect a vulnerable convoy as it travels through hostile territory to the forward operating base.",
+			Phases: []Phase{
+				{
+					Name:        "setup",
+					Description: "Convoy forms up and prepares to depart.",
+					Triggers:    []Trigger{{Event: "time_elapsed", Value: 30, Next: "escalation"}},
+				},
+				{
+					Name:            "escalation",
+					Description:     "Light enemy forces probe the escort.",
+					EnemyObjectives: []EnemyObjective{{ID: "bandits", Action: "harass", Target: "convoy"}},
+					Triggers:        []Trigger{{Event: "enemy_destroyed", Value: 3, Next: "climax"}},
+				},
+				{
+					Name:            "climax",
+					Description:     "A coordinated ambush hits the convoy near a choke point.",
+					EnemyObjectives: []EnemyObjective{{ID: "ambush", Action: "attack", Target: "convoy"}},
+					Triggers:        []Trigger{{Event: "enemy_destroyed", Value: 5, Next: "resolution"}},
+				},
+				{
+					Name:        "resolution",
+					Description: "Remaining threats fall back as the convoy reaches safety.",
+				},
+			},
+		},
+		"search-and-rescue": {
+			Name:        "Search and Rescue",
+			Description: "Locate and recover a downed pilot before hostile forces arrive.",
+			Phases: []Phase{
+				{
+					Name:        "setup",
+					Description: "Rescue team briefs and launches into the search area.",
+					Triggers:    []Trigger{{Event: "time_elapsed", Value: 20, Next: "escalation"}},
+				},
+				{
+					Name:        "escalation",
+					Description: "Search intensifies as signs of the pilot are found.",
+					Triggers:    []Trigger{{Event: "survivor_found", Value: 1, Next: "climax"}},
+				},
+				{
+					Name:            "climax",
+					Description:     "Enemy patrols close in while the extraction is attempted.",
+					EnemyObjectives: []EnemyObjective{{ID: "enemy-patrol", Action: "attack", Target: "rescue-team"}},
+					Triggers:        []Trigger{{Event: "survivor_extracted", Value: 1, Next: "resolution"}},
+				},
+				{
+					Name:        "resolution",
+					Description: "Team departs the area with the survivor; remaining enemies retreat.",
+				},
+			},
+		},
+		"defensive-stand": {
+			Name:        "Defensive Stand",
+			Description: "Hold a critical relay station against waves of hostile drones.",
+			Phases: []Phase{
+				{
+					Name:        "setup",
+					Description: "Defenders fortify the station and establish fields of fire.",
+					Triggers:    []Trigger{{Event: "time_elapsed", Value: 30, Next: "escalation"}},
+				},
+				{
+					Name:            "escalation",
+					Description:     "The first wave tests the defenses.",
+					EnemyObjectives: []EnemyObjective{{ID: "wave1", Action: "attack", Target: "station"}},
+					Triggers:        []Trigger{{Event: "enemy_destroyed", Value: 5, Next: "climax"}},
+				},
+				{
+					Name:            "climax",
+					Description:     "A massive assault threatens to overwhelm the defenders.",
+					EnemyObjectives: []EnemyObjective{{ID: "wave2", Action: "attack", Target: "station"}},
+					Triggers:        []Trigger{{Event: "time_elapsed", Value: 120, Next: "resolution"}},
+				},
+				{
+					Name:        "resolution",
+					Description: "Enemy forces withdraw and the station remains secure.",
+				},
+			},
+		},
+	}
+}

--- a/internal/scenario/scenario.go
+++ b/internal/scenario/scenario.go
@@ -7,9 +7,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Scenario defines a mission scenario with ordered phases.
+// Scenario defines a mission scenario with ordered phases and an overall description.
 type Scenario struct {
-	Phases []Phase `yaml:"phases"`
+	Name        string  `yaml:"name,omitempty"`
+	Description string  `yaml:"description,omitempty"`
+	Phases      []Phase `yaml:"phases"`
 }
 
 // Phase describes a stage in the mission with objectives and triggers for transitions.

--- a/internal/scenario/scenario_test.go
+++ b/internal/scenario/scenario_test.go
@@ -23,10 +23,39 @@ func TestLoadScenario(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load scenario: %v", err)
 	}
+	if sc.Name != "example" {
+		t.Fatalf("unexpected name %s", sc.Name)
+	}
+	if sc.Description != "basic test scenario" {
+		t.Fatalf("unexpected description %s", sc.Description)
+	}
 	if len(sc.Phases) != 2 {
 		t.Fatalf("expected 2 phases, got %d", len(sc.Phases))
 	}
 	if sc.Phases[0].EnemyObjectives[0].Action != "patrol" {
 		t.Fatalf("unexpected objective action %s", sc.Phases[0].EnemyObjectives[0].Action)
+	}
+}
+
+func TestBuiltInArcs(t *testing.T) {
+	arcs := BuiltIn()
+	names := []string{"escort", "search-and-rescue", "defensive-stand"}
+	phases := []string{"setup", "escalation", "climax", "resolution"}
+	for _, n := range names {
+		arc, ok := arcs[n]
+		if !ok {
+			t.Fatalf("arc %s not found", n)
+		}
+		if arc.Description == "" {
+			t.Fatalf("arc %s missing description", n)
+		}
+		if len(arc.Phases) != len(phases) {
+			t.Fatalf("arc %s expected %d phases, got %d", n, len(phases), len(arc.Phases))
+		}
+		for i, ph := range phases {
+			if arc.Phases[i].Name != ph {
+				t.Fatalf("arc %s phase %d expected %s got %s", n, i, ph, arc.Phases[i].Name)
+			}
+		}
 	}
 }

--- a/internal/scenario/testdata/simple.yaml
+++ b/internal/scenario/testdata/simple.yaml
@@ -1,3 +1,5 @@
+name: example
+description: basic test scenario
 phases:
   - name: patrol
     enemy_objectives:


### PR DESCRIPTION
## Summary
- extend Scenario with name and description
- provide built-in story arcs: escort, search-and-rescue, defensive stand
- document arcs and add sample scenario YAMLs

## Testing
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688e45f263508323af4b77b238d8548c