### PR TITLE
feat: enhance 3d map with terrain and missions

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ The Admin WebUI provides a centralized interface for monitoring and managing dro
 - **Chaos Mode Toggle**: Allows users to enable or disable chaos mode, simulating random failures and unpredictable behavior.
 - **Drone Launch Control**: Provides an interface to launch drones for specific missions or operations.
 - **Mission Visualization**: Shows mission objectives, regions, and associated drones.
-- **3D Map Option**: View drone positions on a CesiumJS-based map at `/3d`.
+- **3D Map Option**: Explore an interactive CesiumJS scene with textured terrain, dynamic lighting, and mission annotations at `/3d`.
 - **Interactive Command Console**: Enables direct interaction with the simulator for advanced operations.
 
 ### Access

--- a/internal/admin/server_test.go
+++ b/internal/admin/server_test.go
@@ -112,8 +112,9 @@ func TestHandleHealth(t *testing.T) {
 
 func TestHandleTelemetry(t *testing.T) {
 	cfg := &config.SimulationConfig{
-		Zones:  []config.Region{{Name: "r1", CenterLat: 0, CenterLon: 0, RadiusKM: 1}},
-		Fleets: []config.Fleet{{Name: "f1", Model: "small-fpv", Count: 1}},
+		Zones:    []config.Region{{Name: "r1", CenterLat: 0, CenterLon: 0, RadiusKM: 1}},
+		Fleets:   []config.Fleet{{Name: "f1", Model: "small-fpv", Count: 1}},
+		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "o", Description: "d", Region: config.Region{Name: "r1", CenterLat: 0, CenterLon: 0, RadiusKM: 1}}},
 	}
 
 	simulator := sim.NewSimulator("cluster", cfg, nil, nil, 1)
@@ -138,8 +139,9 @@ func TestHandleTelemetry(t *testing.T) {
 
 func TestHandleMapData(t *testing.T) {
 	cfg := &config.SimulationConfig{
-		Zones:  []config.Region{{Name: "r1", CenterLat: 0, CenterLon: 0, RadiusKM: 1}},
-		Fleets: []config.Fleet{{Name: "f1", Model: "small-fpv", Count: 1}},
+		Zones:    []config.Region{{Name: "r1", CenterLat: 0, CenterLon: 0, RadiusKM: 1}},
+		Fleets:   []config.Fleet{{Name: "f1", Model: "small-fpv", Count: 1}},
+		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "o", Description: "d", Region: config.Region{Name: "r1", CenterLat: 0, CenterLon: 0, RadiusKM: 1}}},
 	}
 
 	simulator := sim.NewSimulator("cluster", cfg, nil, nil, 1)
@@ -162,5 +164,8 @@ func TestHandleMapData(t *testing.T) {
 	}
 	if len(data.Enemies) == 0 {
 		t.Errorf("expected enemies to be included")
+	}
+	if len(data.Missions) != 1 || data.Missions[0].ID != "m1" {
+		t.Errorf("expected mission annotations")
 	}
 }

--- a/internal/admin/templates/map3d.html
+++ b/internal/admin/templates/map3d.html
@@ -10,7 +10,12 @@
 <body>
 <div id="cesiumContainer"></div>
 <script>
-const viewer = new Cesium.Viewer('cesiumContainer');
+const viewer = new Cesium.Viewer('cesiumContainer', {
+  terrainProvider: Cesium.createWorldTerrain(),
+  shadows: true,
+  shouldAnimate: true
+});
+viewer.scene.globe.enableLighting = true;
 async function load(){
   const res = await fetch('/map-data');
   const data = await res.json();
@@ -43,6 +48,20 @@ async function load(){
         }
       });
     }
+  });
+
+  data.missions.forEach(m => {
+    viewer.entities.add({
+      position: Cesium.Cartesian3.fromDegrees(m.lon, m.lat),
+      ellipse: {
+        semiMinorAxis: m.radius_km * 1000,
+        semiMajorAxis: m.radius_km * 1000,
+        material: Cesium.Color.BLUE.withAlpha(0.2),
+        outline: true,
+        outlineColor: Cesium.Color.BLUE
+      },
+      label: { text: m.name, verticalOrigin: Cesium.VerticalOrigin.TOP }
+    });
   });
 }
 setInterval(load, 1000);

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,9 +43,11 @@ type Fleet struct {
 
 // Mission describes a named mission that operates within a zone
 type Mission struct {
+	ID          string `yaml:"id"`
 	Name        string `yaml:"name"`
-	Zone        string `yaml:"zone"`
+	Objective   string `yaml:"objective"`
 	Description string `yaml:"description"`
+	Region      Region `yaml:"region"`
 }
 
 // SimulationConfig is the root configuration for zones, missions, and fleets

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,9 +15,15 @@ zones:
     center_lon: 16.4
     radius_km: 50
 missions:
-  - name: test-mission
-    zone: region-x
+  - id: test
+    name: test-mission
+    objective: test
     description: test
+    region:
+      name: region-x
+      center_lat: 48.2
+      center_lon: 16.4
+      radius_km: 50
 fleets:
   - name: fleet-x
     model: small-fpv
@@ -35,6 +41,9 @@ fleets:
 	}
 	if len(cfg.Fleets) != 1 || cfg.Fleets[0].Name != "fleet-x" {
 		t.Errorf("Unexpected fleet data: %+v", cfg.Fleets)
+	}
+	if len(cfg.Missions) != 1 || cfg.Missions[0].ID != "test" {
+		t.Errorf("Unexpected mission data: %+v", cfg.Missions)
 	}
 }
 

--- a/internal/sim/simulator.go
+++ b/internal/sim/simulator.go
@@ -58,10 +58,20 @@ type MapEnemy struct {
 	Alt  float64         `json:"alt"`
 }
 
-// MapData aggregates drone and enemy positions for the map view.
+// MapMission represents a mission region for annotations on the map.
+type MapMission struct {
+	ID       string  `json:"id"`
+	Name     string  `json:"name"`
+	Lat      float64 `json:"lat"`
+	Lon      float64 `json:"lon"`
+	RadiusKM float64 `json:"radius_km"`
+}
+
+// MapData aggregates drone, enemy, and mission positions for the map view.
 type MapData struct {
-	Drones  []MapDrone `json:"drones"`
-	Enemies []MapEnemy `json:"enemies"`
+	Drones   []MapDrone   `json:"drones"`
+	Enemies  []MapEnemy   `json:"enemies"`
+	Missions []MapMission `json:"missions"`
 }
 
 // Simulator orchestrates fleet telemetry generation and writing.
@@ -723,7 +733,19 @@ func (s *Simulator) MapSnapshot() MapData {
 			})
 		}
 	}
-	return MapData{Drones: drones, Enemies: enemies}
+	var missions []MapMission
+	if s.cfg != nil {
+		for _, m := range s.cfg.Missions {
+			missions = append(missions, MapMission{
+				ID:       m.ID,
+				Name:     m.Name,
+				Lat:      m.Region.CenterLat,
+				Lon:      m.Region.CenterLon,
+				RadiusKM: m.Region.RadiusKM,
+			})
+		}
+	}
+	return MapData{Drones: drones, Enemies: enemies, Missions: missions}
 }
 
 func generateDroneID(fleetName string, index int) string {

--- a/internal/sim/simulator_test.go
+++ b/internal/sim/simulator_test.go
@@ -33,7 +33,7 @@ func (w *MockDetectionWriter) WriteDetection(d enemy.DetectionRow) error {
 func TestSimulator_TickGeneratesTelemetry(t *testing.T) {
 	cfg := &config.SimulationConfig{
 		Zones:    []config.Region{{Name: "region-1", CenterLat: 48.2, CenterLon: 16.4, RadiusKM: 50}},
-		Missions: []config.Mission{{Name: "m1", Zone: "region-1", Description: "test"}},
+		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "", Description: "test", Region: config.Region{Name: "region-1", CenterLat: 48.2, CenterLon: 16.4, RadiusKM: 50}}},
 		Fleets: []config.Fleet{
 			{Name: "fleet-1", Model: "small-fpv", Count: 3, MovementPattern: "patrol", HomeRegion: "region-1"},
 		},
@@ -130,7 +130,7 @@ func TestSimulator_DropoutRate(t *testing.T) {
 func TestSimulator_DetectsEnemy(t *testing.T) {
 	cfg := &config.SimulationConfig{
 		Zones:    []config.Region{{Name: "zone", CenterLat: 48.0, CenterLon: 16.0, RadiusKM: 0.1}},
-		Missions: []config.Mission{{Name: "m1", Zone: "zone", Description: ""}},
+		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "", Description: "", Region: config.Region{Name: "zone", CenterLat: 0, CenterLon: 0, RadiusKM: 10}}},
 		Fleets: []config.Fleet{
 			{Name: "fleet", Model: "small-fpv", Count: 1, MovementPattern: "loiter", HomeRegion: "zone"},
 		},
@@ -162,7 +162,7 @@ func TestSimulator_DetectsEnemy(t *testing.T) {
 func TestSimulator_NoDetectionOutsideRange(t *testing.T) {
 	cfg := &config.SimulationConfig{
 		Zones:    []config.Region{{Name: "zone", CenterLat: 48.0, CenterLon: 16.0, RadiusKM: 0.1}},
-		Missions: []config.Mission{{Name: "m1", Zone: "zone", Description: ""}},
+		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "", Description: "", Region: config.Region{Name: "zone", CenterLat: 0, CenterLon: 0, RadiusKM: 10}}},
 		Fleets: []config.Fleet{
 			{Name: "fleet", Model: "small-fpv", Count: 1, MovementPattern: "loiter", HomeRegion: "zone"},
 		},
@@ -186,7 +186,7 @@ func TestSimulator_NoDetectionOutsideRange(t *testing.T) {
 func TestSimulator_NoPanicWithNilDetectionWriter(t *testing.T) {
 	cfg := &config.SimulationConfig{
 		Zones:    []config.Region{{Name: "zone", CenterLat: 48.0, CenterLon: 16.0, RadiusKM: 0.1}},
-		Missions: []config.Mission{{Name: "m1", Zone: "zone", Description: ""}},
+		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "", Description: "", Region: config.Region{Name: "zone", CenterLat: 0, CenterLon: 0, RadiusKM: 10}}},
 		Fleets: []config.Fleet{
 			{Name: "fleet", Model: "small-fpv", Count: 1, MovementPattern: "loiter", HomeRegion: "zone"},
 		},
@@ -267,7 +267,7 @@ func TestSimulator_NoDetectionOutsideCustomRadius(t *testing.T) {
 func TestSimulator_SwarmFollowHighConfidence(t *testing.T) {
 	cfg := &config.SimulationConfig{
 		Zones:    []config.Region{{Name: "zone", CenterLat: 48.0, CenterLon: 16.0, RadiusKM: 0.1}},
-		Missions: []config.Mission{{Name: "m1", Zone: "zone", Description: ""}},
+		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "", Description: "", Region: config.Region{Name: "zone", CenterLat: 0, CenterLon: 0, RadiusKM: 10}}},
 		Fleets: []config.Fleet{
 			{Name: "fleet", Model: "small-fpv", Count: 2, MovementPattern: "patrol", HomeRegion: "zone"},
 		},
@@ -304,7 +304,7 @@ func TestSimulator_SwarmFollowHighConfidence(t *testing.T) {
 func TestSimulator_SwarmNoFollowBelowConfidence(t *testing.T) {
 	cfg := &config.SimulationConfig{
 		Zones:    []config.Region{{Name: "zone", CenterLat: 48.0, CenterLon: 16.0, RadiusKM: 0.1}},
-		Missions: []config.Mission{{Name: "m1", Zone: "zone", Description: ""}},
+		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "", Description: "", Region: config.Region{Name: "zone", CenterLat: 0, CenterLon: 0, RadiusKM: 10}}},
 		Fleets: []config.Fleet{
 			{Name: "fleet", Model: "small-fpv", Count: 2, MovementPattern: "patrol", HomeRegion: "zone"},
 		},
@@ -336,7 +336,7 @@ func TestSimulator_SwarmNoFollowBelowConfidence(t *testing.T) {
 func TestSimulator_DetectionFactorsReduceConfidence(t *testing.T) {
 	cfg := &config.SimulationConfig{
 		Zones:    []config.Region{{Name: "zone", CenterLat: 48.0, CenterLon: 16.0, RadiusKM: 0.1}},
-		Missions: []config.Mission{{Name: "m1", Zone: "zone", Description: ""}},
+		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "", Description: "", Region: config.Region{Name: "zone", CenterLat: 0, CenterLon: 0, RadiusKM: 10}}},
 		Fleets: []config.Fleet{
 			{Name: "fleet", Model: "small-fpv", Count: 1, MovementPattern: "loiter", HomeRegion: "zone"},
 		},
@@ -374,7 +374,7 @@ func TestSimulator_DetectionFactorsReduceConfidence(t *testing.T) {
 func TestSimulator_PointToPointDetectorFollows(t *testing.T) {
 	cfg := &config.SimulationConfig{
 		Zones:    []config.Region{{Name: "zone", CenterLat: 0, CenterLon: 0, RadiusKM: 0.1}},
-		Missions: []config.Mission{{Name: "m1", Zone: "zone", Description: ""}},
+		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "", Description: "", Region: config.Region{Name: "zone", CenterLat: 0, CenterLon: 0, RadiusKM: 10}}},
 		Fleets: []config.Fleet{
 			{Name: "fleet", Model: "small-fpv", Count: 2, MovementPattern: "point-to-point", HomeRegion: "zone"},
 		},
@@ -451,7 +451,7 @@ func TestSimulator_PredictiveInterception(t *testing.T) {
 func TestSimulator_PatrolResponseCount(t *testing.T) {
 	cfg := &config.SimulationConfig{
 		Zones:    []config.Region{{Name: "zone", CenterLat: 0, CenterLon: 0, RadiusKM: 0}},
-		Missions: []config.Mission{{Name: "m1", Zone: "zone", Description: ""}},
+		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "", Description: "", Region: config.Region{Name: "zone", CenterLat: 0, CenterLon: 0, RadiusKM: 10}}},
 		Fleets: []config.Fleet{
 			{Name: "fleet", Model: "small-fpv", Count: 3, MovementPattern: "patrol", HomeRegion: "zone"},
 		},
@@ -481,7 +481,7 @@ func TestSimulator_PatrolResponseCount(t *testing.T) {
 func TestSimulator_LoiterResponseCount(t *testing.T) {
 	cfg := &config.SimulationConfig{
 		Zones:    []config.Region{{Name: "zone", CenterLat: 0, CenterLon: 0, RadiusKM: 0}},
-		Missions: []config.Mission{{Name: "m1", Zone: "zone", Description: ""}},
+		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "", Description: "", Region: config.Region{Name: "zone", CenterLat: 0, CenterLon: 0, RadiusKM: 10}}},
 		Fleets: []config.Fleet{
 			{Name: "fleet", Model: "small-fpv", Count: 3, MovementPattern: "loiter", HomeRegion: "zone"},
 		},
@@ -511,7 +511,7 @@ func TestSimulator_LoiterResponseCount(t *testing.T) {
 func TestSimulator_ThreatAdaptiveFollowers(t *testing.T) {
 	cfg := &config.SimulationConfig{
 		Zones:    []config.Region{{Name: "zone", CenterLat: 0, CenterLon: 0, RadiusKM: 0}},
-		Missions: []config.Mission{{Name: "m1", Zone: "zone", Description: ""}},
+		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "", Description: "", Region: config.Region{Name: "zone", CenterLat: 0, CenterLon: 0, RadiusKM: 10}}},
 		Fleets: []config.Fleet{
 			{Name: "fleet", Model: "small-fpv", Count: 4, MovementPattern: "patrol", HomeRegion: "zone"},
 		},

--- a/schemas/simulation.cue
+++ b/schemas/simulation.cue
@@ -9,9 +9,16 @@ zones: [...{
 }]
 
 missions: [...{
+    id:          string & !=""
     name:        string & !=""
-    zone:        string
+    objective:   string
     description: string
+    region: {
+        name:       string & !=""
+        center_lat: number
+        center_lon: number
+        radius_km:  number & >0
+    }
 }]
 
 fleets: [...{


### PR DESCRIPTION
## Summary
- add textured terrain, dynamic lighting, and mission overlays to Cesium 3D map
- expose mission regions via MapData and configuration updates
- document new interactive 3D map features

## Testing
- `make test`
- `cue vet config/simulation.yaml schemas/simulation.cue` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688e5d287774832391e46c1ab417f07a