### PR TITLE
feat(admin): add observer dashboard and APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It supports:
 - **Configurable sensor errors, communication dropouts, and battery anomalies**
 - **Output to GreptimeDB** using its gRPC ORM interface **or** to STDOUT for quick demos
 - **Mission scenarios** scripted with a lightweight DSL for phases and enemy objectives
+- **Observer dashboard** for stepping through mission events, switching perspectives, and injecting commands
 
 This project was designed to support visualization dashboards (e.g., Grafana Geomap panel) and multi-cluster sync scenarios (mission clusters → command cluster).
 

--- a/internal/admin/templates/observer.html
+++ b/internal/admin/templates/observer.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Observer Dashboard</title>
+<style>
+body{background:#111;color:#eee;font-family:Arial,Helvetica,sans-serif;margin:0;padding:20px;}
+button{padding:8px 16px;margin:5px;background:#444;color:#fff;border:none;cursor:pointer;}
+button:hover{background:#666;}
+input{padding:5px;margin:5px;background:#222;color:#fff;border:1px solid #444;}
+#events{list-style:none;padding:0;}
+#events li{padding:4px 0;}
+#events li.active{font-weight:bold;}
+</style>
+</head>
+<body>
+<h1>Observer Dashboard</h1>
+<ul id="events"></ul>
+<button onclick="prev()">Prev</button>
+<button onclick="next()">Next</button>
+<div>
+  <input id="droneId" placeholder="Drone ID">
+  <button onclick="setPerspective()">Set Perspective</button>
+</div>
+<div>
+  <input id="cmd" placeholder="Scripted command">
+  <button onclick="inject()">Inject</button>
+</div>
+<script>
+let events=[];let idx=0;
+function loadEvents(){
+ fetch('/observer/events').then(r=>r.json()).then(data=>{events=data;render();});
+}
+function render(){
+ const list=document.getElementById('events');
+ list.innerHTML='';
+ events.forEach((e,i)=>{
+  const li=document.createElement('li');
+  li.textContent=i+': '+e.type+' '+(e.details||'');
+  if(i===idx)li.className='active';
+  list.appendChild(li);
+ });
+}
+function step(){fetch('/observer/step?index='+idx,{method:'POST'}).then(render);}
+function prev(){if(idx>0){idx--;step();}}
+function next(){if(idx<events.length-1){idx++;step();}}
+function setPerspective(){const id=document.getElementById('droneId').value;fetch('/observer/perspective?drone='+id,{method:'POST'});}
+function inject(){const c=document.getElementById('cmd').value;fetch('/observer/command?cmd='+encodeURIComponent(c),{method:'POST'}).then(loadEvents);}
+loadEvents();
+</script>
+</body>
+</html>

--- a/internal/sim/simulator.go
+++ b/internal/sim/simulator.go
@@ -74,6 +74,13 @@ type MapData struct {
 	Missions []MapMission `json:"missions"`
 }
 
+// ObserverEvent represents a mission event used by analyst tools.
+type ObserverEvent struct {
+	Timestamp time.Time `json:"timestamp"`
+	Type      string    `json:"type"`
+	Details   string    `json:"details,omitempty"`
+}
+
 // Simulator orchestrates fleet telemetry generation and writing.
 type Simulator struct {
 	clusterID            string
@@ -102,6 +109,9 @@ type Simulator struct {
 	enemyObjects         map[string]*enemy.Enemy
 	droneIndex           map[string]*telemetry.Drone
 	droneFleet           map[string]*DroneFleet
+	observerEvents       []ObserverEvent
+	observerIdx          int
+	observerPerspective  string
 	mu                   sync.Mutex
 }
 
@@ -611,6 +621,7 @@ func (s *Simulator) ToggleChaos() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.chaosMode = !s.chaosMode
+	s.logObserverEvent("toggle_chaos", fmt.Sprintf("enabled=%v", s.chaosMode))
 	return s.chaosMode
 }
 
@@ -639,6 +650,7 @@ func (s *Simulator) LaunchSwarm(model string, count int) {
 		f.Drones = append(f.Drones, drone)
 	}
 	s.fleets = append(s.fleets, f)
+	s.logObserverEvent("launch_swarm", fmt.Sprintf("model=%s count=%d", model, count))
 }
 
 // FleetHealth summarizes status counts per fleet.
@@ -746,6 +758,52 @@ func (s *Simulator) MapSnapshot() MapData {
 		}
 	}
 	return MapData{Drones: drones, Enemies: enemies, Missions: missions}
+}
+
+// ObserverEvents returns a copy of all recorded mission events.
+func (s *Simulator) ObserverEvents() []ObserverEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	events := make([]ObserverEvent, len(s.observerEvents))
+	copy(events, s.observerEvents)
+	return events
+}
+
+// ObserverStep sets the current event index and returns the event at that position.
+func (s *Simulator) ObserverStep(idx int) (ObserverEvent, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if idx < 0 || idx >= len(s.observerEvents) {
+		return ObserverEvent{}, false
+	}
+	s.observerIdx = idx
+	return s.observerEvents[idx], true
+}
+
+// ObserverSetPerspective selects a drone to observe.
+func (s *Simulator) ObserverSetPerspective(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.observerPerspective = id
+	s.logObserverEvent("perspective", id)
+}
+
+// ObserverPerspective returns the current drone perspective.
+func (s *Simulator) ObserverPerspective() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.observerPerspective
+}
+
+// ObserverInjectCommand records a scripted command.
+func (s *Simulator) ObserverInjectCommand(cmd string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.logObserverEvent("command", cmd)
+}
+
+func (s *Simulator) logObserverEvent(t, details string) {
+	s.observerEvents = append(s.observerEvents, ObserverEvent{Timestamp: time.Now().UTC(), Type: t, Details: details})
 }
 
 func generateDroneID(fleetName string, index int) string {

--- a/internal/sim/simulator_test.go
+++ b/internal/sim/simulator_test.go
@@ -637,3 +637,25 @@ func TestSimulator_FollowerFailover(t *testing.T) {
 		t.Fatalf("expected replacement follower to be assigned")
 	}
 }
+
+func TestObserverTools(t *testing.T) {
+	cfg := &config.SimulationConfig{
+		Zones:  []config.Region{{Name: "r1", CenterLat: 0, CenterLon: 0, RadiusKM: 1}},
+		Fleets: []config.Fleet{{Name: "f1", Model: "small-fpv", Count: 1}},
+	}
+	sim := NewSimulator("cluster", cfg, nil, nil, 1)
+	sim.ObserverInjectCommand("test")
+	events := sim.ObserverEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ev, ok := sim.ObserverStep(0)
+	if !ok || ev.Type != "command" {
+		t.Fatalf("unexpected step result: %+v", ev)
+	}
+	droneID := sim.TelemetrySnapshot()[0].DroneID
+	sim.ObserverSetPerspective(droneID)
+	if sim.ObserverPerspective() != droneID {
+		t.Fatalf("expected perspective %s, got %s", droneID, sim.ObserverPerspective())
+	}
+}


### PR DESCRIPTION
## Summary
- add observer event tracking to simulator with command injection and perspective selection
- expose observer APIs and dashboard in admin server
- document observer dashboard in README

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688e5ffd24c48323b1ce2d4da1ef5929