### PR TITLE
refactor: simplify writer setup

### DIFF
--- a/cmd/droneops-sim/writer.go
+++ b/cmd/droneops-sim/writer.go
@@ -9,38 +9,40 @@ import (
 // newWriters sets up telemetry and detection writers based on flags and env vars.
 // It returns the writers and a cleanup function to close any resources.
 func newWriters(printOnly bool, logFile string) (sim.TelemetryWriter, sim.DetectionWriter, func(), error) {
-	var writer sim.TelemetryWriter
-	var detectWriter sim.DetectionWriter
 	cleanup := func() {}
 
+	writer, detectWriter, err := baseWriters(printOnly)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if logFile == "" {
+		return writer, detectWriter, cleanup, nil
+	}
+
+	fw, err := sim.NewFileWriter(logFile, logFile+".detections")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	mw := sim.NewMultiWriter([]sim.TelemetryWriter{writer, fw}, []sim.DetectionWriter{detectWriter, fw})
+	cleanup = func() { fw.Close() }
+	return mw, mw, cleanup, nil
+}
+
+// baseWriters chooses the underlying writers based on printOnly flag and env vars.
+func baseWriters(printOnly bool) (sim.TelemetryWriter, sim.DetectionWriter, error) {
 	if printOnly || os.Getenv("GREPTIMEDB_ENDPOINT") == "" {
 		sw := &sim.StdoutWriter{}
-		writer = sw
-		detectWriter = sw
-	} else {
-		endpoint := os.Getenv("GREPTIMEDB_ENDPOINT")
-		table := os.Getenv("GREPTIMEDB_TABLE")
-		detTable := os.Getenv("ENEMY_DETECTION_TABLE")
-		w, err := sim.NewGreptimeDBWriter(endpoint, "public", table, detTable)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		writer = w
-		detectWriter = w
+		return sw, sw, nil
 	}
 
-	if logFile != "" {
-		fw, err := sim.NewFileWriter(logFile, logFile+".detections")
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		mw := sim.NewMultiWriter([]sim.TelemetryWriter{writer, fw}, []sim.DetectionWriter{detectWriter, fw})
-		writer = mw
-		detectWriter = mw
-		cleanup = func() { fw.Close() }
+	endpoint := os.Getenv("GREPTIMEDB_ENDPOINT")
+	table := os.Getenv("GREPTIMEDB_TABLE")
+	detTable := os.Getenv("ENEMY_DETECTION_TABLE")
+	w, err := sim.NewGreptimeDBWriter(endpoint, "public", table, detTable)
+	if err != nil {
+		return nil, nil, err
 	}
-
-	return writer, detectWriter, cleanup, nil
+	return w, w, nil
 }
 
 // newTelemetryWriter creates a telemetry writer without detection handling.

--- a/cmd/droneops-sim/writer_test.go
+++ b/cmd/droneops-sim/writer_test.go
@@ -24,6 +24,21 @@ func TestNewWritersPrintOnly(t *testing.T) {
 	}
 }
 
+func TestNewWritersGreptimeFallback(t *testing.T) {
+	t.Setenv("GREPTIMEDB_ENDPOINT", "")
+	tw, dw, cleanup, err := newWriters(false, "")
+	if err != nil {
+		t.Fatalf("newWriters returned error: %v", err)
+	}
+	cleanup()
+	if _, ok := tw.(*sim.StdoutWriter); !ok {
+		t.Fatalf("expected *sim.StdoutWriter, got %T", tw)
+	}
+	if _, ok := dw.(*sim.StdoutWriter); !ok {
+		t.Fatalf("expected *sim.StdoutWriter, got %T", dw)
+	}
+}
+
 func TestNewWritersLogFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "telemetry.log")


### PR DESCRIPTION
## Summary
- simplify writer setup by splitting writer selection and file wrapping
- add fallback test for missing GreptimeDB endpoint

## Testing
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688f074a7d9483238612f06dfc437ca9