### PR TITLE
refactor: centralize thresholds and simplify battery status

### DIFF
--- a/internal/enemy/engine.go
+++ b/internal/enemy/engine.go
@@ -10,6 +10,8 @@ import (
 	"droneops-sim/internal/telemetry"
 )
 
+const nearDroneDistThreshold = 0.005 // degrees, ~500m
+
 // Engine maintains and updates simulated enemy entities.
 type Engine struct {
 	regions   []telemetry.Region
@@ -125,7 +127,7 @@ func nearestEnemy(cur *Enemy, enemies []*Enemy) (*Enemy, float64) {
 
 func (e *Engine) respondToNearbyDrone(en *Enemy, drones []*telemetry.Drone) bool {
 	nearest, dist := nearestDrone(en.Position, drones)
-	if nearest != nil && dist < 0.005 { // ~500m
+	if nearest != nil && dist < nearDroneDistThreshold {
 		en.Position = moveAway(en.Position, nearest.Position)
 		if e.randFloat() < 0.3 {
 			e.spawnDecoy(en)

--- a/internal/sim/simulator.go
+++ b/internal/sim/simulator.go
@@ -17,6 +17,11 @@ import (
 	"github.com/google/uuid"
 )
 
+const (
+	sensorErrorMaxOffset   = 0.005 // degrees (~500m)
+	interceptLateralMeters = 50.0  // lateral spacing between intercept points
+)
+
 // TelemetryWriter is an interface to support different output writers.
 type TelemetryWriter interface {
 	Write(telemetry.TelemetryRow) error
@@ -323,8 +328,8 @@ func (s *Simulator) updateDrone(drone *telemetry.Drone) (telemetry.TelemetryRow,
 	}
 	row := s.teleGen.GenerateTelemetry(drone)
 	if rand.Float64() < drone.SensorErrorRate {
-		row.Lat += rand.Float64()*0.01 - 0.005
-		row.Lon += rand.Float64()*0.01 - 0.005
+		row.Lat += rand.Float64()*sensorErrorMaxOffset*2 - sensorErrorMaxOffset
+		row.Lon += rand.Float64()*sensorErrorMaxOffset*2 - sensorErrorMaxOffset
 	}
 	if rand.Float64() < drone.BatteryAnomalyRate {
 		drop := rand.Float64()*20 + 10
@@ -620,7 +625,7 @@ func (s *Simulator) interceptPoints(en *enemy.Enemy, n int) []telemetry.Position
 		perpLat = -velLon / norm
 		perpLon = velLat / norm
 	}
-	lateral := 50.0
+	lateral := interceptLateralMeters
 	latStep := lateral / 111000
 	lonStep := lateral / (111000 * math.Cos(predicted.Lat*math.Pi/180))
 	for i := 0; i < n; i++ {

--- a/internal/telemetry/generator.go
+++ b/internal/telemetry/generator.go
@@ -47,13 +47,7 @@ func (g *Generator) GenerateTelemetry(drone *Drone) TelemetryRow {
 	}
 
 	// Status
-	if drone.Battery <= 5 {
-		drone.Status = StatusFailure
-	} else if drone.Battery <= 20 {
-		drone.Status = StatusLowBattery
-	} else {
-		drone.Status = StatusOK
-	}
+	drone.Status = batteryStatus(drone.Battery)
 
 	return TelemetryRow{
 		ClusterID:  g.ClusterID,
@@ -179,6 +173,18 @@ func (f FollowMovement) Move(drone *Drone, region Region, waypoints []Position) 
 		Lat: drone.Position.Lat + deltaLat,
 		Lon: drone.Position.Lon + deltaLon,
 		Alt: drone.Position.Alt,
+	}
+}
+
+// batteryStatus determines the drone status based on remaining battery level.
+func batteryStatus(level float64) string {
+	switch {
+	case level <= BatteryFailureThreshold:
+		return StatusFailure
+	case level <= BatteryLowThreshold:
+		return StatusLowBattery
+	default:
+		return StatusOK
 	}
 }
 

--- a/internal/telemetry/types.go
+++ b/internal/telemetry/types.go
@@ -83,3 +83,9 @@ const (
 	StatusLowBattery = "low_battery"
 	StatusFailure    = "failed"
 )
+
+// Battery status thresholds in percentage.
+const (
+	BatteryFailureThreshold = 5.0  // Battery at or below this is a failure
+	BatteryLowThreshold     = 20.0 // Battery at or below this is low
+)


### PR DESCRIPTION
## Summary
- extract battery and spatial thresholds into constants
- simplify battery status check with helper

## Testing
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688f09b4d724832395a8f0e3d9140f33