### PR TITLE
feat: enable deterministic simulation with injected sources

### DIFF
--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"embed"
 	"encoding/json"
 	"html/template"
@@ -43,9 +44,14 @@ func (s *Server) routes() {
 	http.HandleFunc("/observer/command", s.handleObserverCommand)
 }
 
-func (s *Server) Start(addr string) error {
+func (s *Server) Start(ctx context.Context, addr string) error {
 	s.routes()
-	return http.ListenAndServe(addr, nil)
+	srv := &http.Server{Addr: addr}
+	go func() {
+		<-ctx.Done()
+		srv.Shutdown(context.Background())
+	}()
+	return srv.ListenAndServe()
 }
 
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin/server_test.go
+++ b/internal/admin/server_test.go
@@ -2,9 +2,11 @@ package admin
 
 import (
 	"encoding/json"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"droneops-sim/internal/config"
 	"droneops-sim/internal/sim"
@@ -17,7 +19,7 @@ func TestHandleToggleChaos(t *testing.T) {
 		Zones:  []config.Region{{Name: "region-1", CenterLat: 48.2, CenterLon: 16.4, RadiusKM: 50}},
 		Fleets: []config.Fleet{{Name: "fleet-1", Model: "small-fpv", Count: 3}},
 	}
-	sim := sim.NewSimulator("test-cluster", cfg, nil, nil, 1)
+	sim := sim.NewSimulator("test-cluster", cfg, nil, nil, 1, rand.New(rand.NewSource(1)), func() time.Time { return time.Unix(0, 0).UTC() })
 	server := NewServer(sim)
 
 	// Create a request to toggle chaos
@@ -54,7 +56,7 @@ func TestHandleLaunchDrones(t *testing.T) {
 		Zones:  []config.Region{{Name: "region-1", CenterLat: 48.2, CenterLon: 16.4, RadiusKM: 50}},
 		Fleets: []config.Fleet{{Name: "fleet-1", Model: "small-fpv", Count: 3}},
 	}
-	sim := sim.NewSimulator("test-cluster", cfg, nil, nil, 1)
+	sim := sim.NewSimulator("test-cluster", cfg, nil, nil, 1, rand.New(rand.NewSource(1)), func() time.Time { return time.Unix(0, 0).UTC() })
 	server := NewServer(sim)
 
 	// Create a request to launch drones
@@ -90,7 +92,7 @@ func TestHandleHealth(t *testing.T) {
 		Zones:  []config.Region{{Name: "region-1", CenterLat: 48.2, CenterLon: 16.4, RadiusKM: 50}},
 		Fleets: []config.Fleet{{Name: "fleet-1", Model: "small-fpv", Count: 1}},
 	}
-	simulator := sim.NewSimulator("cluster", cfg, nil, nil, 1)
+	simulator := sim.NewSimulator("cluster", cfg, nil, nil, 1, rand.New(rand.NewSource(1)), func() time.Time { return time.Unix(0, 0).UTC() })
 	server := NewServer(simulator)
 
 	req := httptest.NewRequest(http.MethodGet, "/fleet-health", nil)
@@ -117,7 +119,7 @@ func TestHandleTelemetry(t *testing.T) {
 		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "o", Description: "d", Region: config.Region{Name: "r1", CenterLat: 0, CenterLon: 0, RadiusKM: 1}}},
 	}
 
-	simulator := sim.NewSimulator("cluster", cfg, nil, nil, 1)
+	simulator := sim.NewSimulator("cluster", cfg, nil, nil, 1, rand.New(rand.NewSource(1)), func() time.Time { return time.Unix(0, 0).UTC() })
 	server := NewServer(simulator)
 
 	req := httptest.NewRequest(http.MethodGet, "/telemetry", nil)
@@ -144,7 +146,7 @@ func TestHandleMapData(t *testing.T) {
 		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "o", Description: "d", Region: config.Region{Name: "r1", CenterLat: 0, CenterLon: 0, RadiusKM: 1}}},
 	}
 
-	simulator := sim.NewSimulator("cluster", cfg, nil, nil, 1)
+	simulator := sim.NewSimulator("cluster", cfg, nil, nil, 1, rand.New(rand.NewSource(1)), func() time.Time { return time.Unix(0, 0).UTC() })
 	server := NewServer(simulator)
 
 	req := httptest.NewRequest(http.MethodGet, "/map-data", nil)
@@ -175,7 +177,7 @@ func TestObserverEndpoints(t *testing.T) {
 		Zones:  []config.Region{{Name: "r1", CenterLat: 0, CenterLon: 0, RadiusKM: 1}},
 		Fleets: []config.Fleet{{Name: "f1", Model: "small-fpv", Count: 1}},
 	}
-	simulator := sim.NewSimulator("cluster", cfg, nil, nil, 1)
+	simulator := sim.NewSimulator("cluster", cfg, nil, nil, 1, rand.New(rand.NewSource(1)), func() time.Time { return time.Unix(0, 0).UTC() })
 	server := NewServer(simulator)
 
 	// inject command

--- a/internal/telemetry/generator.go
+++ b/internal/telemetry/generator.go
@@ -9,11 +9,19 @@ import (
 // Generator simulates telemetry for a fleet of drones.
 type Generator struct {
 	ClusterID string
+	rand      *rand.Rand
+	now       func() time.Time
 }
 
 // NewGenerator creates a new telemetry generator for a given cluster.
-func NewGenerator(clusterID string) *Generator {
-	return &Generator{ClusterID: clusterID}
+func NewGenerator(clusterID string, r *rand.Rand, now func() time.Time) *Generator {
+	if r == nil {
+		r = rand.New(rand.NewSource(time.Now().UnixNano()))
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return &Generator{ClusterID: clusterID, rand: r, now: now}
 }
 
 // GenerateTelemetry updates a drone's state and returns a TelemetryRow ready for DB write.
@@ -38,7 +46,7 @@ func (g *Generator) GenerateTelemetry(drone *Drone) TelemetryRow {
 	}
 
 	// Update drone's position using the selected strategy
-	drone.Position = strategy.Move(drone, drone.HomeRegion, drone.Waypoints)
+	drone.Position = strategy.Move(drone, drone.HomeRegion, drone.Waypoints, g.rand)
 
 	// Battery drain
 	drone.Battery -= batteryDrain(drone.Model)
@@ -61,21 +69,21 @@ func (g *Generator) GenerateTelemetry(drone *Drone) TelemetryRow {
 		SyncedFrom: "",
 		SyncedID:   "",
 		SyncedAt:   time.Time{},
-		Timestamp:  time.Now().UTC(),
+		Timestamp:  g.now().UTC(),
 	}
 }
 
 // MovementStrategy defines the interface for drone movement.
 type MovementStrategy interface {
-	Move(drone *Drone, region Region, waypoints []Position) Position
+	Move(drone *Drone, region Region, waypoints []Position, r *rand.Rand) Position
 }
 
 // PatrolMovement implements circular movement around the home region's center.
 type PatrolMovement struct{}
 
-func (p PatrolMovement) Move(drone *Drone, region Region, waypoints []Position) Position {
+func (p PatrolMovement) Move(drone *Drone, region Region, waypoints []Position, r *rand.Rand) Position {
 	radius := region.RadiusKM * 1000 * 0.99 // Scale radius slightly to ensure position stays within bounds
-	angle := rand.Float64() * 2 * math.Pi
+	angle := r.Float64() * 2 * math.Pi
 	deltaLat := (radius * math.Cos(angle)) / 111000
 	deltaLon := (radius * math.Sin(angle)) / (111000 * math.Cos(region.CenterLat*math.Pi/180))
 	return Position{
@@ -88,11 +96,11 @@ func (p PatrolMovement) Move(drone *Drone, region Region, waypoints []Position) 
 // PointToPointMovement implements movement between predefined waypoints.
 type PointToPointMovement struct{}
 
-func (p PointToPointMovement) Move(drone *Drone, region Region, waypoints []Position) Position {
+func (p PointToPointMovement) Move(drone *Drone, region Region, waypoints []Position, r *rand.Rand) Position {
 	if len(waypoints) == 0 {
 		return drone.Position
 	}
-	target := waypoints[rand.Intn(len(waypoints))]
+	target := waypoints[r.Intn(len(waypoints))]
 	deltaLat := (target.Lat - drone.Position.Lat) / 10 // Gradual movement
 	deltaLon := (target.Lon - drone.Position.Lon) / 10
 	return Position{
@@ -105,9 +113,9 @@ func (p PointToPointMovement) Move(drone *Drone, region Region, waypoints []Posi
 // LoiterMovement implements hovering near the home region's center.
 type LoiterMovement struct{}
 
-func (l LoiterMovement) Move(drone *Drone, region Region, waypoints []Position) Position {
-	deltaLat := rand.Float64()*0.0001 - 0.00005 // Small random movement
-	deltaLon := rand.Float64()*0.0001 - 0.00005
+func (l LoiterMovement) Move(drone *Drone, region Region, waypoints []Position, r *rand.Rand) Position {
+	deltaLat := r.Float64()*0.0001 - 0.00005 // Small random movement
+	deltaLon := r.Float64()*0.0001 - 0.00005
 	return Position{
 		Lat: region.CenterLat + deltaLat,
 		Lon: region.CenterLon + deltaLon,
@@ -118,7 +126,7 @@ func (l LoiterMovement) Move(drone *Drone, region Region, waypoints []Position) 
 // RandomWalkMovement implements random movement within the region.
 type RandomWalkMovement struct{}
 
-func (r RandomWalkMovement) Move(drone *Drone, region Region, waypoints []Position) Position {
+func (r RandomWalkMovement) Move(drone *Drone, region Region, waypoints []Position, rnd *rand.Rand) Position {
 	var speedMin, speedMax float64 // speed range, in meters
 	switch drone.Model {
 	case "small-fpv":
@@ -132,17 +140,17 @@ func (r RandomWalkMovement) Move(drone *Drone, region Region, waypoints []Positi
 	}
 
 	// Random heading (direction) in radians (0 to 2π)
-	heading := rand.Float64() * 2 * math.Pi
+	heading := rnd.Float64() * 2 * math.Pi
 
 	// Random speed within the range for the drone model
-	speed := rand.Float64()*(speedMax-speedMin) + speedMin // m/s
+	speed := rnd.Float64()*(speedMax-speedMin) + speedMin // m/s
 
 	// Convert speed and heading into latitude and longitude deltas
 	deltaLat := (speed * math.Cos(heading)) / 111000
 	deltaLon := (speed * math.Sin(heading)) / (111000 * math.Cos(drone.Position.Lat*math.Pi/180))
 
 	// Altitude delta: random change between -1m and +1m
-	altDelta := rand.Float64()*2 - 1 // ±1m
+	altDelta := rnd.Float64()*2 - 1 // ±1m
 
 	// Return the new position, ensuring altitude is non-negative
 	return Position{
@@ -155,7 +163,7 @@ func (r RandomWalkMovement) Move(drone *Drone, region Region, waypoints []Positi
 // FollowMovement moves the drone toward a target position.
 type FollowMovement struct{ Target Position }
 
-func (f FollowMovement) Move(drone *Drone, region Region, waypoints []Position) Position {
+func (f FollowMovement) Move(drone *Drone, region Region, waypoints []Position, r *rand.Rand) Position {
 	const step = 50.0 // meters per tick
 	dLat := (f.Target.Lat - drone.Position.Lat) * 111000
 	dLon := (f.Target.Lon - drone.Position.Lon) * 111000 * math.Cos(drone.Position.Lat*math.Pi/180)


### PR DESCRIPTION
## Summary
- inject controllable rand and clock sources across simulation components
- run simulator and admin server with context cancellation
- add tests for chaos toggling, deterministic follower assignment, and enemy reactions

## Testing
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688f0be5fa3483238c499ae8f846b56c