### PR TITLE
chore: correct CLI usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,4 @@ WORKDIR /
 COPY --from=builder /droneops-sim /droneops-sim
 
 ENTRYPOINT ["/droneops-sim"]
+CMD ["simulate"]

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 
 run:
 	$(MAKE) build
-	$(BIN) --config config/simulation.yaml --schema schemas/simulation.cue --print-only
+	$(BIN) simulate --config config/simulation.yaml --schema schemas/simulation.cue --print-only
 
 docker:
 	docker build -t $(APP_NAME):latest .

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -42,7 +42,7 @@ To write to GreptimeDB instead, set the endpoint and table variables:
 export GREPTIMEDB_ENDPOINT=127.0.0.1:4001
 export GREPTIMEDB_TABLE=drone_telemetry
 export ENEMY_DETECTION_TABLE=enemy_detection
-./build/droneops-sim
+./build/droneops-sim simulate
 ```
 
 The admin web UI will be available on `http://localhost:8080`.
@@ -69,7 +69,7 @@ Build and run the simulator in a container:
 make docker
 # or manually
 # docker build -t droneops-sim:latest .
-# docker run --rm -p 8080:8080 droneops-sim:latest
+# docker run --rm -p 8080:8080 droneops-sim:latest simulate
 ```
 
 ## Kubernetes

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,7 @@ make run
 export GREPTIMEDB_ENDPOINT=127.0.0.1:4001
 export GREPTIMEDB_TABLE=drone_telemetry
 export ENEMY_DETECTION_TABLE=enemy_detection
-./build/droneops-sim
+./build/droneops-sim simulate
 ```
 
 Docker run:
@@ -26,6 +26,6 @@ docker run --rm \
     -e GREPTIMEDB_ENDPOINT=127.0.0.1:4001 \
     -e GREPTIMEDB_TABLE=drone_telemetry \
     -e ENEMY_DETECTION_TABLE=enemy_detection \
-    droneops-sim:latest
+    droneops-sim:latest simulate
 ```
 

--- a/helm/droneops-sim/templates/deployment.yaml
+++ b/helm/droneops-sim/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
+          - "simulate"
           - "--config"
           - "/etc/{{ .Chart.Name }}/config/simulation.yaml"
           - "--schema"


### PR DESCRIPTION
## Summary
- run simulator via `simulate` subcommand in Makefile and Docker image
- document updated CLI examples and Helm args

## Testing
- `cue vet config/simulation.yaml schemas/simulation.cue` *(fails: cue not installed)*
- `make test`
- `make run` (terminated after startup)


------
https://chatgpt.com/codex/tasks/task_e_688f43061e248323b92dd14b685519fe