### PR TITLE
feat(sim): include mission ID in telemetry

### DIFF
--- a/config/simulation.yaml
+++ b/config/simulation.yaml
@@ -36,6 +36,7 @@ fleets:
     count: 20
     movement_pattern: patrol
     home_region: central-europe
+    mission_id: recon
     behavior:
       battery_drain_rate: 0.5
       failure_rate: 0.02
@@ -49,6 +50,7 @@ fleets:
     count: 5
     movement_pattern: point-to-point
     home_region: central-europe
+    mission_id: firewall
     behavior:
       battery_drain_rate: 0.3
       failure_rate: 0.01
@@ -62,6 +64,7 @@ fleets:
     count: 2
     movement_pattern: loiter
     home_region: central-europe
+    mission_id: firewall
     behavior:
       battery_drain_rate: 0.2
       failure_rate: 0.005

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,7 @@ type Fleet struct {
 	Count           int      `yaml:"count"`
 	MovementPattern string   `yaml:"movement_pattern"`
 	HomeRegion      string   `yaml:"home_region"`
+	MissionID       string   `yaml:"mission_id"`
 	Behavior        Behavior `yaml:"behavior"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,6 +30,7 @@ fleets:
     count: 2
     movement_pattern: patrol
     home_region: region-x
+    mission_id: test
 `
 	if err := os.WriteFile(tmpFile, []byte(yaml), 0644); err != nil {
 		t.Fatalf("failed to write temp file: %v", err)
@@ -41,6 +42,9 @@ fleets:
 	}
 	if len(cfg.Fleets) != 1 || cfg.Fleets[0].Name != "fleet-x" {
 		t.Errorf("Unexpected fleet data: %+v", cfg.Fleets)
+	}
+	if cfg.Fleets[0].MissionID != "test" {
+		t.Errorf("expected mission_id 'test', got %s", cfg.Fleets[0].MissionID)
 	}
 	if len(cfg.Missions) != 1 || cfg.Missions[0].ID != "test" {
 		t.Errorf("Unexpected mission data: %+v", cfg.Missions)

--- a/internal/sim/simulator.go
+++ b/internal/sim/simulator.go
@@ -204,6 +204,7 @@ func NewSimulator(clusterID string, cfg *config.SimulationConfig, writer Telemet
 			drone := &telemetry.Drone{
 				ID:              generateDroneID(fleet.Name, i),
 				Model:           fleet.Model,
+				MissionID:       fleet.MissionID,
 				Position:        telemetry.Position{Lat: cfg.Zones[0].CenterLat, Lon: cfg.Zones[0].CenterLon, Alt: 100},
 				Battery:         100,
 				Status:          telemetry.StatusOK,
@@ -332,6 +333,7 @@ func (s *Simulator) TelemetrySnapshot() []telemetry.TelemetryRow {
 			rows = append(rows, telemetry.TelemetryRow{
 				ClusterID: s.clusterID,
 				DroneID:   drone.ID,
+				MissionID: drone.MissionID,
 				Lat:       drone.Position.Lat,
 				Lon:       drone.Position.Lon,
 				Alt:       drone.Position.Alt,

--- a/internal/sim/simulator_test.go
+++ b/internal/sim/simulator_test.go
@@ -36,7 +36,7 @@ func TestSimulator_TickGeneratesTelemetry(t *testing.T) {
 		Zones:    []config.Region{{Name: "region-1", CenterLat: 48.2, CenterLon: 16.4, RadiusKM: 50}},
 		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "", Description: "test", Region: config.Region{Name: "region-1", CenterLat: 48.2, CenterLon: 16.4, RadiusKM: 50}}},
 		Fleets: []config.Fleet{
-			{Name: "fleet-1", Model: "small-fpv", Count: 3, MovementPattern: "patrol", HomeRegion: "region-1"},
+			{Name: "fleet-1", Model: "small-fpv", Count: 3, MovementPattern: "patrol", HomeRegion: "region-1", MissionID: "m1"},
 		},
 	}
 	writer := &MockWriter{}
@@ -52,6 +52,9 @@ func TestSimulator_TickGeneratesTelemetry(t *testing.T) {
 	for _, row := range writer.Rows {
 		if row.DroneID == "" || row.ClusterID == "" {
 			t.Errorf("Telemetry row has missing IDs: %+v", row)
+		}
+		if row.MissionID != "m1" {
+			t.Errorf("expected mission ID m1, got %s", row.MissionID)
 		}
 	}
 }

--- a/internal/telemetry/generator.go
+++ b/internal/telemetry/generator.go
@@ -60,6 +60,7 @@ func (g *Generator) GenerateTelemetry(drone *Drone) TelemetryRow {
 	return TelemetryRow{
 		ClusterID:  g.ClusterID,
 		DroneID:    drone.ID,
+		MissionID:  drone.MissionID,
 		Lat:        drone.Position.Lat,
 		Lon:        drone.Position.Lon,
 		Alt:        drone.Position.Alt,

--- a/internal/telemetry/generator_test.go
+++ b/internal/telemetry/generator_test.go
@@ -11,11 +11,12 @@ func TestGenerateTelemetry(t *testing.T) {
 	fixed := time.Unix(0, 0).UTC()
 	gen := NewGenerator("cluster-1", rand.New(rand.NewSource(1)), func() time.Time { return fixed })
 	drone := &Drone{
-		ID:       "drone-001",
-		Model:    "small-fpv",
-		Position: Position{Lat: 48.2082, Lon: 16.3738, Alt: 100},
-		Battery:  50,
-		Status:   StatusOK,
+		ID:        "drone-001",
+		Model:     "small-fpv",
+		MissionID: "m1",
+		Position:  Position{Lat: 48.2082, Lon: 16.3738, Alt: 100},
+		Battery:   50,
+		Status:    StatusOK,
 	}
 
 	row := gen.GenerateTelemetry(drone)
@@ -25,6 +26,9 @@ func TestGenerateTelemetry(t *testing.T) {
 	}
 	if row.DroneID != "drone-001" {
 		t.Errorf("expected drone-001, got %s", row.DroneID)
+	}
+	if row.MissionID != "m1" {
+		t.Errorf("expected mission ID m1, got %s", row.MissionID)
 	}
 	if row.SyncedFrom != "" || row.SyncedID != "" || !row.SyncedAt.IsZero() {
 		t.Errorf("expected unsynced defaults, got %+v", row)

--- a/internal/telemetry/types.go
+++ b/internal/telemetry/types.go
@@ -50,6 +50,7 @@ func (TelemetryRow) TableName() string {
 type Drone struct {
 	ID                 string     // Drone ID
 	Model              string     // Drone model
+	MissionID          string     // Associated mission ID
 	Position           Position   // Current position
 	Battery            float64    // Battery level
 	Status             string     // Current status

--- a/schemas/simulation.cue
+++ b/schemas/simulation.cue
@@ -2,53 +2,54 @@
 package schemas
 
 zones: [...{
-    name:        string & !=""
-    center_lat:  number
-    center_lon:  number
-    radius_km:   number & >0
+	name:       string & !=""
+	center_lat: number
+	center_lon: number
+	radius_km:  number & >0
 }]
 
 missions: [...{
-    id:          string & !=""
-    name:        string & !=""
-    objective:   string
-    description: string
-    region: {
-        name:       string & !=""
-        center_lat: number
-        center_lon: number
-        radius_km:  number & >0
-    }
+	id:          string & !=""
+	name:        string & !=""
+	objective:   string
+	description: string
+	region: {
+		name:       string & !=""
+		center_lat: number
+		center_lon: number
+		radius_km:  number & >0
+	}
 }]
 
 fleets: [...{
-    name:             string & !=""
-    model:            =~"small-fpv|medium-uav|large-uav"
-    count:            int & >0
-    movement_pattern: =~"patrol|point-to-point|loiter"
-    home_region:      string
-    behavior?: {
-        battery_drain_rate?: number & >=0
-        failure_rate?:       number & >=0 & <=1
-        speed_min_kmh?:      number & >=0
-        speed_max_kmh?:      number & >=0
-        sensor_error_rate?:  number & >=0 & <=1
-        dropout_rate?:       number & >=0 & <=1
-        battery_anomaly_rate?: number & >=0 & <=1
-    }
+	name:             string & !=""
+	model:            =~"small-fpv|medium-uav|large-uav"
+	count:            int & >0
+	movement_pattern: =~"patrol|point-to-point|loiter"
+	home_region:      string
+	mission_id:       string & !=""
+	behavior?: {
+		battery_drain_rate?:   number & >=0
+		failure_rate?:         number & >=0 & <=1
+		speed_min_kmh?:        number & >=0
+		speed_max_kmh?:        number & >=0
+		sensor_error_rate?:    number & >=0 & <=1
+		dropout_rate?:         number & >=0 & <=1
+		battery_anomaly_rate?: number & >=0 & <=1
+	}
 }]
 
 follow_confidence?: number & >=0 & <=100
 
-swarm_responses?: { [=~"patrol|point-to-point|loiter"]: int }
+swarm_responses?: {[=~"patrol|point-to-point|loiter"]: int}
 
 mission_criticality?: =~"low|medium|high"
 
 enemy_count?: int & >=0
 
 detection_radius_m?: number & >0
-sensor_noise?: number & >=0
-terrain_occlusion?: number & >=0 & <=1
-weather_impact?: number & >=0 & <=1
+sensor_noise?:       number & >=0
+terrain_occlusion?:  number & >=0 & <=1
+weather_impact?:     number & >=0 & <=1
 communication_loss?: number & >=0 & <=1
-bandwidth_limit?: int & >=0
+bandwidth_limit?:    int & >=0


### PR DESCRIPTION
## Summary
- add mission_id to fleets and telemetry drones
- propagate mission IDs to generated telemetry and snapshots
- test that mission IDs appear in telemetry rows

## Testing
- `cue vet config/simulation.yaml schemas/simulation.cue`
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688f640469cc83238e079131733fb8fc