### PR TITLE
refactor: split stdout writers into color and json implementations

### DIFF
--- a/cmd/droneops-sim/writer.go
+++ b/cmd/droneops-sim/writer.go
@@ -32,8 +32,8 @@ func newWriters(cfg *config.SimulationConfig, printOnly bool, logFile string) (s
 // baseWriters chooses the underlying writers based on printOnly flag and env vars.
 func baseWriters(cfg *config.SimulationConfig, printOnly bool) (sim.TelemetryWriter, sim.DetectionWriter, error) {
 	if printOnly || os.Getenv("GREPTIMEDB_ENDPOINT") == "" {
-		sw := sim.NewStdoutWriter(cfg)
-		return sw, sw, nil
+		tw, dw := sim.NewStdoutWriters(cfg)
+		return tw, dw, nil
 	}
 
 	endpoint := os.Getenv("GREPTIMEDB_ENDPOINT")

--- a/cmd/droneops-sim/writer_test.go
+++ b/cmd/droneops-sim/writer_test.go
@@ -16,11 +16,11 @@ func TestNewWritersPrintOnly(t *testing.T) {
 		t.Fatalf("newWriters returned error: %v", err)
 	}
 	cleanup()
-	if _, ok := tw.(*sim.StdoutWriter); !ok {
-		t.Fatalf("expected *sim.StdoutWriter, got %T", tw)
+	if _, ok := tw.(*sim.JSONStdoutWriter); !ok {
+		t.Fatalf("expected *sim.JSONStdoutWriter, got %T", tw)
 	}
-	if _, ok := dw.(*sim.StdoutWriter); !ok {
-		t.Fatalf("expected *sim.StdoutWriter, got %T", dw)
+	if _, ok := dw.(*sim.JSONStdoutWriter); !ok {
+		t.Fatalf("expected *sim.JSONStdoutWriter, got %T", dw)
 	}
 }
 
@@ -31,11 +31,11 @@ func TestNewWritersGreptimeFallback(t *testing.T) {
 		t.Fatalf("newWriters returned error: %v", err)
 	}
 	cleanup()
-	if _, ok := tw.(*sim.StdoutWriter); !ok {
-		t.Fatalf("expected *sim.StdoutWriter, got %T", tw)
+	if _, ok := tw.(*sim.JSONStdoutWriter); !ok {
+		t.Fatalf("expected *sim.JSONStdoutWriter, got %T", tw)
 	}
-	if _, ok := dw.(*sim.StdoutWriter); !ok {
-		t.Fatalf("expected *sim.StdoutWriter, got %T", dw)
+	if _, ok := dw.(*sim.JSONStdoutWriter); !ok {
+		t.Fatalf("expected *sim.JSONStdoutWriter, got %T", dw)
 	}
 }
 

--- a/internal/sim/stdout_color_writer.go
+++ b/internal/sim/stdout_color_writer.go
@@ -1,0 +1,141 @@
+// ColorStdoutWriter prints human-friendly, colorized telemetry to STDOUT.
+package sim
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"text/tabwriter"
+	"time"
+
+	"droneops-sim/internal/config"
+	"droneops-sim/internal/enemy"
+	"droneops-sim/internal/telemetry"
+)
+
+const (
+	colorReset   = "\x1b[0m"
+	colorRed     = "\x1b[31m"
+	colorGreen   = "\x1b[32m"
+	colorYellow  = "\x1b[33m"
+	colorBlue    = "\x1b[34m"
+	colorMagenta = "\x1b[35m"
+	colorCyan    = "\x1b[36m"
+	colorGray    = "\x1b[90m"
+)
+
+// ColorStdoutWriter prints telemetry rows using ANSI colors.
+type ColorStdoutWriter struct {
+	cfg           *config.SimulationConfig
+	out           io.Writer
+	once          sync.Once
+	missionColors map[string]string
+	colorIdx      int
+}
+
+var missionPalette = []string{colorRed, colorGreen, colorYellow, colorBlue, colorMagenta, colorCyan}
+
+// NewColorStdoutWriter creates a ColorStdoutWriter writing to os.Stdout.
+func NewColorStdoutWriter(cfg *config.SimulationConfig) *ColorStdoutWriter {
+	return &ColorStdoutWriter{
+		cfg:           cfg,
+		out:           os.Stdout,
+		missionColors: make(map[string]string),
+	}
+}
+
+func (w *ColorStdoutWriter) getMissionColor(id string) string {
+	if c, ok := w.missionColors[id]; ok {
+		return c
+	}
+	c := missionPalette[w.colorIdx%len(missionPalette)]
+	w.missionColors[id] = c
+	w.colorIdx++
+	return c
+}
+
+func (w *ColorStdoutWriter) printOverview() {
+	if w.cfg == nil {
+		return
+	}
+
+	fmt.Fprintln(w.out, "Simulation Configuration:")
+	tw := tabwriter.NewWriter(w.out, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "Follow Confidence:\t%.0f\n", w.cfg.FollowConfidence)
+	fmt.Fprintf(tw, "Mission Criticality:\t%s\n", w.cfg.MissionCriticality)
+	fmt.Fprintf(tw, "Detection Radius (m):\t%.0f\n", w.cfg.DetectionRadiusM)
+	fmt.Fprintf(tw, "Sensor Noise:\t%.2f\n", w.cfg.SensorNoise)
+	fmt.Fprintf(tw, "Terrain Occlusion:\t%.2f\n", w.cfg.TerrainOcclusion)
+	fmt.Fprintf(tw, "Weather Impact:\t%.2f\n", w.cfg.WeatherImpact)
+	fmt.Fprintf(tw, "Communication Loss:\t%.2f\n", w.cfg.CommunicationLoss)
+	fmt.Fprintf(tw, "Bandwidth Limit:\t%d\n", w.cfg.BandwidthLimit)
+	tw.Flush()
+
+	fmt.Fprintln(w.out, "\nMissions:")
+	tw = tabwriter.NewWriter(w.out, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "ID\tName\tObjective\n")
+	for _, m := range w.cfg.Missions {
+		col := w.getMissionColor(m.ID)
+		fmt.Fprintf(tw, "%s%s%s\t%s\t%s\n", col, m.ID, colorReset, m.Name, m.Objective)
+	}
+	tw.Flush()
+	fmt.Fprintln(w.out)
+}
+
+// Write outputs a single telemetry row in colorized format.
+func (w *ColorStdoutWriter) Write(row telemetry.TelemetryRow) error {
+	w.once.Do(w.printOverview)
+
+	mColor := w.getMissionColor(row.MissionID)
+	statusColor := colorGreen
+	switch row.Status {
+	case telemetry.StatusFailure:
+		statusColor = colorRed
+	case telemetry.StatusLowBattery:
+		statusColor = colorYellow
+	}
+
+	fmt.Fprintf(w.out, "%s[%s]%s ", colorGray, row.Timestamp.Format(time.RFC3339), colorReset)
+	fmt.Fprintf(w.out, "%scluster=%s%s ", colorBlue, row.ClusterID, colorReset)
+	fmt.Fprintf(w.out, "%smission=%s%s ", mColor, row.MissionID, colorReset)
+	fmt.Fprintf(w.out, "%sdrone=%s%s ", colorWhite(), row.DroneID, colorReset)
+	fmt.Fprintf(w.out, "%slat=%.5f%s ", colorGreen, row.Lat, colorReset)
+	fmt.Fprintf(w.out, "%slon=%.5f%s ", colorYellow, row.Lon, colorReset)
+	fmt.Fprintf(w.out, "%salt=%.1f%s ", colorMagenta, row.Alt, colorReset)
+	fmt.Fprintf(w.out, "%sbatt=%.1f%s ", colorCyan, row.Battery, colorReset)
+	fmt.Fprintf(w.out, "%sstatus=%s%s", statusColor, row.Status, colorReset)
+	if row.Follow {
+		fmt.Fprintf(w.out, " %sfollow%s", colorMagenta, colorReset)
+	}
+	fmt.Fprintln(w.out)
+	return nil
+}
+
+func colorWhite() string { return "\x1b[37m" }
+
+// WriteBatch outputs multiple telemetry rows.
+func (w *ColorStdoutWriter) WriteBatch(rows []telemetry.TelemetryRow) error {
+	for _, r := range rows {
+		_ = w.Write(r)
+	}
+	return nil
+}
+
+// WriteDetection prints an enemy detection event to STDOUT.
+func (w *ColorStdoutWriter) WriteDetection(d enemy.DetectionRow) error {
+	w.once.Do(w.printOverview)
+	fmt.Fprintf(w.out, "%s[%s]%s %sDETECTION%s drone=%s enemy=%s type=%s lat=%.5f lon=%.5f alt=%.1f conf=%.2f\n",
+		colorGray, d.Timestamp.Format(time.RFC3339), colorReset,
+		colorRed, colorReset, d.DroneID, d.EnemyID, d.EnemyType,
+		d.Lat, d.Lon, d.Alt, d.Confidence)
+	return nil
+}
+
+// WriteDetections prints multiple enemy detections.
+func (w *ColorStdoutWriter) WriteDetections(rows []enemy.DetectionRow) error {
+	for _, d := range rows {
+		_ = w.WriteDetection(d)
+	}
+	return nil
+}

--- a/internal/sim/stdout_json_writer.go
+++ b/internal/sim/stdout_json_writer.go
@@ -1,0 +1,51 @@
+package sim
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"droneops-sim/internal/enemy"
+	"droneops-sim/internal/telemetry"
+)
+
+// JSONStdoutWriter prints telemetry and detections as JSON to STDOUT.
+type JSONStdoutWriter struct {
+	out io.Writer
+}
+
+// NewJSONStdoutWriter creates a JSONStdoutWriter writing to os.Stdout.
+func NewJSONStdoutWriter() *JSONStdoutWriter {
+	return &JSONStdoutWriter{out: os.Stdout}
+}
+
+// Write outputs a telemetry row in JSON format.
+func (w *JSONStdoutWriter) Write(row telemetry.TelemetryRow) error {
+	data, _ := json.Marshal(row)
+	fmt.Fprintln(w.out, string(data))
+	return nil
+}
+
+// WriteBatch outputs multiple telemetry rows in JSON format.
+func (w *JSONStdoutWriter) WriteBatch(rows []telemetry.TelemetryRow) error {
+	for _, r := range rows {
+		_ = w.Write(r)
+	}
+	return nil
+}
+
+// WriteDetection outputs an enemy detection event in JSON format.
+func (w *JSONStdoutWriter) WriteDetection(d enemy.DetectionRow) error {
+	data, _ := json.Marshal(d)
+	fmt.Fprintln(w.out, string(data))
+	return nil
+}
+
+// WriteDetections outputs multiple enemy detections in JSON format.
+func (w *JSONStdoutWriter) WriteDetections(rows []enemy.DetectionRow) error {
+	for _, d := range rows {
+		_ = w.WriteDetection(d)
+	}
+	return nil
+}

--- a/internal/sim/stdout_writer.go
+++ b/internal/sim/stdout_writer.go
@@ -1,158 +1,20 @@
-// Writer implementation printing telemetry to STDOUT with optional colorized output.
 package sim
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
 	"os"
-	"sync"
-	"text/tabwriter"
-	"time"
 
 	"golang.org/x/term"
 
 	"droneops-sim/internal/config"
-	"droneops-sim/internal/enemy"
-	"droneops-sim/internal/telemetry"
 )
 
-const (
-	colorReset   = "\x1b[0m"
-	colorRed     = "\x1b[31m"
-	colorGreen   = "\x1b[32m"
-	colorYellow  = "\x1b[33m"
-	colorBlue    = "\x1b[34m"
-	colorMagenta = "\x1b[35m"
-	colorCyan    = "\x1b[36m"
-	colorGray    = "\x1b[90m"
-)
-
-// StdoutWriter prints telemetry rows to STDOUT.
-type StdoutWriter struct {
-	cfg           *config.SimulationConfig
-	colorize      bool
-	out           io.Writer
-	once          sync.Once
-	missionColors map[string]string
-	colorIdx      int
-}
-
-var missionPalette = []string{colorRed, colorGreen, colorYellow, colorBlue, colorMagenta, colorCyan}
-
-// NewStdoutWriter creates a StdoutWriter.
-func NewStdoutWriter(cfg *config.SimulationConfig) *StdoutWriter {
-	colorize := term.IsTerminal(int(os.Stdout.Fd()))
-	return &StdoutWriter{
-		cfg:           cfg,
-		colorize:      colorize,
-		out:           os.Stdout,
-		missionColors: make(map[string]string),
+// NewStdoutWriters selects a stdout writer based on terminal capability.
+// It returns both telemetry and detection writers.
+func NewStdoutWriters(cfg *config.SimulationConfig) (TelemetryWriter, DetectionWriter) {
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		w := NewColorStdoutWriter(cfg)
+		return w, w
 	}
-}
-
-func (w *StdoutWriter) getMissionColor(id string) string {
-	if c, ok := w.missionColors[id]; ok {
-		return c
-	}
-	c := missionPalette[w.colorIdx%len(missionPalette)]
-	w.missionColors[id] = c
-	w.colorIdx++
-	return c
-}
-
-func (w *StdoutWriter) printOverview() {
-	if w.cfg == nil {
-		return
-	}
-
-	fmt.Fprintln(w.out, "Simulation Configuration:")
-	tw := tabwriter.NewWriter(w.out, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, "Follow Confidence:\t%.0f\n", w.cfg.FollowConfidence)
-	fmt.Fprintf(tw, "Mission Criticality:\t%s\n", w.cfg.MissionCriticality)
-	fmt.Fprintf(tw, "Detection Radius (m):\t%.0f\n", w.cfg.DetectionRadiusM)
-	fmt.Fprintf(tw, "Sensor Noise:\t%.2f\n", w.cfg.SensorNoise)
-	fmt.Fprintf(tw, "Terrain Occlusion:\t%.2f\n", w.cfg.TerrainOcclusion)
-	fmt.Fprintf(tw, "Weather Impact:\t%.2f\n", w.cfg.WeatherImpact)
-	fmt.Fprintf(tw, "Communication Loss:\t%.2f\n", w.cfg.CommunicationLoss)
-	fmt.Fprintf(tw, "Bandwidth Limit:\t%d\n", w.cfg.BandwidthLimit)
-	tw.Flush()
-
-	fmt.Fprintln(w.out, "\nMissions:")
-	tw = tabwriter.NewWriter(w.out, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, "ID\tName\tObjective\n")
-	for _, m := range w.cfg.Missions {
-		col := w.getMissionColor(m.ID)
-		fmt.Fprintf(tw, "%s%s%s\t%s\t%s\n", col, m.ID, colorReset, m.Name, m.Objective)
-	}
-	tw.Flush()
-	fmt.Fprintln(w.out)
-}
-
-// Write outputs a single telemetry row.
-func (w *StdoutWriter) Write(row telemetry.TelemetryRow) error {
-	if !w.colorize {
-		data, _ := json.Marshal(row)
-		fmt.Fprintln(w.out, string(data))
-		return nil
-	}
-
-	w.once.Do(w.printOverview)
-
-	mColor := w.getMissionColor(row.MissionID)
-	statusColor := colorGreen
-	switch row.Status {
-	case telemetry.StatusFailure:
-		statusColor = colorRed
-	case telemetry.StatusLowBattery:
-		statusColor = colorYellow
-	}
-
-	fmt.Fprintf(w.out, "%s[%s]%s ", colorGray, row.Timestamp.Format(time.RFC3339), colorReset)
-	fmt.Fprintf(w.out, "%scluster=%s%s ", colorBlue, row.ClusterID, colorReset)
-	fmt.Fprintf(w.out, "%smission=%s%s ", mColor, row.MissionID, colorReset)
-	fmt.Fprintf(w.out, "%sdrone=%s%s ", colorWhite(), row.DroneID, colorReset)
-	fmt.Fprintf(w.out, "%slat=%.5f%s ", colorGreen, row.Lat, colorReset)
-	fmt.Fprintf(w.out, "%slon=%.5f%s ", colorYellow, row.Lon, colorReset)
-	fmt.Fprintf(w.out, "%salt=%.1f%s ", colorMagenta, row.Alt, colorReset)
-	fmt.Fprintf(w.out, "%sbatt=%.1f%s ", colorCyan, row.Battery, colorReset)
-	fmt.Fprintf(w.out, "%sstatus=%s%s", statusColor, row.Status, colorReset)
-	if row.Follow {
-		fmt.Fprintf(w.out, " %sfollow%s", colorMagenta, colorReset)
-	}
-	fmt.Fprintln(w.out)
-	return nil
-}
-
-func colorWhite() string { return "\x1b[37m" }
-
-// WriteBatch outputs multiple telemetry rows.
-func (w *StdoutWriter) WriteBatch(rows []telemetry.TelemetryRow) error {
-	for _, r := range rows {
-		_ = w.Write(r)
-	}
-	return nil
-}
-
-// WriteDetection prints an enemy detection event to STDOUT.
-func (w *StdoutWriter) WriteDetection(d enemy.DetectionRow) error {
-	if !w.colorize {
-		data, _ := json.Marshal(d)
-		fmt.Fprintln(w.out, string(data))
-		return nil
-	}
-	w.once.Do(w.printOverview)
-	fmt.Fprintf(w.out, "%s[%s]%s %sDETECTION%s drone=%s enemy=%s type=%s lat=%.5f lon=%.5f alt=%.1f conf=%.2f\n",
-		colorGray, d.Timestamp.Format(time.RFC3339), colorReset,
-		colorRed, colorReset, d.DroneID, d.EnemyID, d.EnemyType,
-		d.Lat, d.Lon, d.Alt, d.Confidence)
-	return nil
-}
-
-// WriteDetections prints multiple enemy detections.
-func (w *StdoutWriter) WriteDetections(rows []enemy.DetectionRow) error {
-	for _, d := range rows {
-		_ = w.WriteDetection(d)
-	}
-	return nil
+	w := NewJSONStdoutWriter()
+	return w, w
 }

--- a/internal/sim/stdout_writer_test.go
+++ b/internal/sim/stdout_writer_test.go
@@ -10,9 +10,9 @@ import (
 	"droneops-sim/internal/telemetry"
 )
 
-func TestStdoutWriterJSONFallback(t *testing.T) {
+func TestJSONStdoutWriter(t *testing.T) {
 	buf := &bytes.Buffer{}
-	w := &StdoutWriter{out: buf, colorize: false, missionColors: make(map[string]string)}
+	w := &JSONStdoutWriter{out: buf}
 	row := telemetry.TelemetryRow{ClusterID: "c1", DroneID: "d1", Timestamp: time.Unix(0, 0)}
 	if err := w.Write(row); err != nil {
 		t.Fatalf("write failed: %v", err)
@@ -22,10 +22,10 @@ func TestStdoutWriterJSONFallback(t *testing.T) {
 	}
 }
 
-func TestStdoutWriterColorized(t *testing.T) {
+func TestColorStdoutWriter(t *testing.T) {
 	cfg := &config.SimulationConfig{FollowConfidence: 50, MissionCriticality: "medium", DetectionRadiusM: 100, Missions: []config.Mission{{ID: "m1", Name: "Alpha", Objective: "test"}}}
 	buf := &bytes.Buffer{}
-	w := &StdoutWriter{cfg: cfg, colorize: true, out: buf, missionColors: make(map[string]string)}
+	w := &ColorStdoutWriter{cfg: cfg, out: buf, missionColors: make(map[string]string)}
 	row := telemetry.TelemetryRow{ClusterID: "c1", DroneID: "d1", MissionID: "m1", Lat: 1, Lon: 2, Alt: 3, Battery: 4, Status: telemetry.StatusOK, Timestamp: time.Unix(0, 0)}
 	if err := w.Write(row); err != nil {
 		t.Fatalf("write failed: %v", err)


### PR DESCRIPTION
## Summary
- extract ColorStdoutWriter for ANSI-colored output
- add JSONStdoutWriter and factory selecting writer based on TTY
- update writer setup and tests for new writers

## Testing
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688f8f729ed08323a6741a7ddb3031dd