### PR TITLE
feat: enhance enemy detection telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,4 +250,6 @@ The simulator includes an enemy detection subsystem used to test how drones reac
 - Every drone checks for enemies within a configurable detection radius (default: 1&nbsp;km) each tick. Confidence is influenced by distance as well as sensor noise, terrain occlusion and weather conditions.
 - Detection events are written to the table specified by `ENEMY_DETECTION_TABLE` when writing to GreptimeDB, or printed to STDOUT in print-only mode.
 
+Each detection record captures the detecting drone's coordinates, the enemy's location, range and bearing from the drone, and an estimated enemy velocity.
+
 See [docs/enemy-detection.md](docs/enemy-detection.md) for more details on the available settings and event format.

--- a/docs/enemy-detection.md
+++ b/docs/enemy-detection.md
@@ -20,10 +20,18 @@ grouping, and decoy tactics. A detection event is emitted whenever a drone is wi
 6. The number of drones that follow depends on the base `swarm_responses` setting and may increase with detection confidence, enemy type, or mission criticality.
 7. Drones that remain in formation are automatically reassigned to new patrol points to keep coverage balanced.
 
-The event structure is defined in `internal/enemy/types.go` and contains fields such as `enemy_id`,
-`enemy_type`, latitude/longitude, confidence and timestamp.
+The event structure is defined in `internal/enemy/types.go` and now also includes the detecting drone's
+coordinates, distance to the target, relative bearing, and estimated enemy velocity in meters per second.
 
 Drone telemetry rows now include a `follow` field indicating whether the drone is actively tracking a target.
+
+### Detection Event Fields
+
+Each detection row includes additional telemetry:
+- `drone_lat`, `drone_lon`, `drone_alt` – position of the detecting drone
+- `distance_m` – range to the target in meters
+- `bearing_deg` – relative bearing from the drone to the enemy
+- `enemy_velocity_mps` – estimated enemy speed in meters per second
 
 ## Configuration Options
 
@@ -62,6 +70,12 @@ no effect.
   "lat": 48.201,
   "lon": 16.403,
   "alt": 0,
+  "drone_lat": 48.199,
+  "drone_lon": 16.398,
+  "drone_alt": 100,
+  "distance_m": 150.5,
+  "bearing_deg": 85.2,
+  "enemy_velocity_mps": 12.3,
   "confidence": 87.5,
   "ts": "2024-06-24T12:00:00Z"
 }

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -332,6 +332,22 @@
           }
         ]
       }
+    },
+    {
+      "id": 16,
+      "type": "histogram",
+      "title": "Detection Distance",
+      "description": "Distribution of enemy distance from drones.",
+      "gridPos": { "x": 0, "y": 88, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "refId": "Q",
+          "datasource": { "type": "greptimedb", "uid": "YOUR_GREPTIMEDB_UID" },
+          "rawSql": "SELECT distance_m FROM enemy_detection WHERE $__timeFilter(ts)",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] }
     }
   ],
   "templating": {

--- a/internal/enemy/types.go
+++ b/internal/enemy/types.go
@@ -34,6 +34,12 @@ type DetectionRow struct {
 	Lat        float64   `json:"lat"`
 	Lon        float64   `json:"lon"`
 	Alt        float64   `json:"alt"`
+	DroneLat   float64   `json:"drone_lat"`
+	DroneLon   float64   `json:"drone_lon"`
+	DroneAlt   float64   `json:"drone_alt"`
+	DistanceM  float64   `json:"distance_m"`
+	BearingDeg float64   `json:"bearing_deg"`
+	EnemyVelMS float64   `json:"enemy_velocity_mps"`
 	Confidence float64   `json:"confidence"`
 	Timestamp  time.Time `json:"ts"`
 }

--- a/internal/enemy/types_test.go
+++ b/internal/enemy/types_test.go
@@ -1,0 +1,40 @@
+package enemy
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestDetectionRowJSON(t *testing.T) {
+	d := DetectionRow{
+		ClusterID:  "c",
+		DroneID:    "d",
+		EnemyID:    "e",
+		EnemyType:  EnemyVehicle,
+		Lat:        1,
+		Lon:        2,
+		Alt:        3,
+		DroneLat:   4,
+		DroneLon:   5,
+		DroneAlt:   6,
+		DistanceM:  7,
+		BearingDeg: 8,
+		EnemyVelMS: 9,
+		Confidence: 10,
+		Timestamp:  time.Unix(0, 0).UTC(),
+	}
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"drone_lat", "drone_lon", "drone_alt", "distance_m", "bearing_deg", "enemy_velocity_mps"} {
+		if _, ok := m[key]; !ok {
+			t.Fatalf("missing %s in json: %s", key, string(data))
+		}
+	}
+}

--- a/internal/sim/detection_writer.go
+++ b/internal/sim/detection_writer.go
@@ -1,0 +1,13 @@
+package sim
+
+import "droneops-sim/internal/enemy"
+
+// DetectionWriter handles enemy detection events.
+type DetectionWriter interface {
+	WriteDetection(enemy.DetectionRow) error
+}
+
+// Optional: Detection writers may support batch mode.
+type batchDetectionWriter interface {
+	WriteDetections([]enemy.DetectionRow) error
+}

--- a/internal/sim/file_writer_test.go
+++ b/internal/sim/file_writer_test.go
@@ -25,7 +25,23 @@ func TestFileWriter(t *testing.T) {
 	if err := fw.Write(tRow); err != nil {
 		t.Fatalf("Write telemetry: %v", err)
 	}
-	dRow := enemy.DetectionRow{ClusterID: "c1", DroneID: "d1", EnemyID: "e1", EnemyType: enemy.EnemyVehicle, Timestamp: time.Unix(0, 0)}
+	dRow := enemy.DetectionRow{
+		ClusterID:  "c1",
+		DroneID:    "d1",
+		EnemyID:    "e1",
+		EnemyType:  enemy.EnemyVehicle,
+		Lat:        1,
+		Lon:        2,
+		Alt:        3,
+		DroneLat:   4,
+		DroneLon:   5,
+		DroneAlt:   6,
+		DistanceM:  7,
+		BearingDeg: 8,
+		EnemyVelMS: 9,
+		Confidence: 50,
+		Timestamp:  time.Unix(0, 0),
+	}
 	if err := fw.WriteDetection(dRow); err != nil {
 		t.Fatalf("Write detection: %v", err)
 	}
@@ -53,7 +69,7 @@ func TestFileWriter(t *testing.T) {
 	if err := json.Unmarshal(dData, &gotD); err != nil {
 		t.Fatalf("decode det: %v", err)
 	}
-	if gotD.EnemyID != dRow.EnemyID {
+	if gotD.EnemyID != dRow.EnemyID || gotD.DistanceM != dRow.DistanceM {
 		t.Fatalf("unexpected detection row: %+v", gotD)
 	}
 }

--- a/internal/sim/greptime_writer.go
+++ b/internal/sim/greptime_writer.go
@@ -129,6 +129,12 @@ func (w *GreptimeDBWriter) WriteDetections(rows []enemy.DetectionRow) error {
 	tbl.AddFieldColumn("lat", types.FLOAT64)
 	tbl.AddFieldColumn("lon", types.FLOAT64)
 	tbl.AddFieldColumn("alt", types.FLOAT64)
+	tbl.AddFieldColumn("drone_lat", types.FLOAT64)
+	tbl.AddFieldColumn("drone_lon", types.FLOAT64)
+	tbl.AddFieldColumn("drone_alt", types.FLOAT64)
+	tbl.AddFieldColumn("distance_m", types.FLOAT64)
+	tbl.AddFieldColumn("bearing_deg", types.FLOAT64)
+	tbl.AddFieldColumn("enemy_velocity_mps", types.FLOAT64)
 	tbl.AddFieldColumn("confidence", types.FLOAT64)
 	tbl.AddTimestampColumn("ts", types.TIMESTAMP_MILLISECOND)
 
@@ -141,6 +147,12 @@ func (w *GreptimeDBWriter) WriteDetections(rows []enemy.DetectionRow) error {
 			r.Lat,
 			r.Lon,
 			r.Alt,
+			r.DroneLat,
+			r.DroneLon,
+			r.DroneAlt,
+			r.DistanceM,
+			r.BearingDeg,
+			r.EnemyVelMS,
 			r.Confidence,
 			r.Timestamp,
 		)

--- a/internal/sim/simulator.go
+++ b/internal/sim/simulator.go
@@ -25,16 +25,6 @@ type TelemetryWriter interface {
 	Write(telemetry.TelemetryRow) error
 }
 
-// DetectionWriter handles enemy detection events.
-type DetectionWriter interface {
-	WriteDetection(enemy.DetectionRow) error
-}
-
-// Optional: Detection writers may support batch mode
-type batchDetectionWriter interface {
-	WriteDetections([]enemy.DetectionRow) error
-}
-
 // Optional: Writers can also support batch mode
 type batchWriter interface {
 	WriteBatch([]telemetry.TelemetryRow) error
@@ -406,4 +396,18 @@ func distanceMeters(lat1, lon1, lat2, lon2 float64) float64 {
 	a := math.Sin(dLat/2)*math.Sin(dLat/2) + math.Cos(lat1*math.Pi/180)*math.Cos(lat2*math.Pi/180)*math.Sin(dLon/2)*math.Sin(dLon/2)
 	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
 	return earthRadius * c
+}
+
+// bearingDegrees calculates the initial bearing from point A to B.
+func bearingDegrees(lat1, lon1, lat2, lon2 float64) float64 {
+	lat1Rad := lat1 * math.Pi / 180
+	lat2Rad := lat2 * math.Pi / 180
+	dLon := (lon2 - lon1) * math.Pi / 180
+	y := math.Sin(dLon) * math.Cos(lat2Rad)
+	x := math.Cos(lat1Rad)*math.Sin(lat2Rad) - math.Sin(lat1Rad)*math.Cos(lat2Rad)*math.Cos(dLon)
+	brng := math.Atan2(y, x) * 180 / math.Pi
+	if brng < 0 {
+		brng += 360
+	}
+	return brng
 }

--- a/internal/sim/tick.go
+++ b/internal/sim/tick.go
@@ -151,6 +151,11 @@ func (s *Simulator) processDetections(fleet *DroneFleet, drone *telemetry.Drone)
 		} else if conf > 100 {
 			conf = 100
 		}
+		var vel float64
+		if prev, ok := s.enemyPrevPositions[en.ID]; ok && s.tickInterval > 0 {
+			vel = distanceMeters(prev.Lat, prev.Lon, en.Position.Lat, en.Position.Lon) / s.tickInterval.Seconds()
+		}
+		bearing := bearingDegrees(drone.Position.Lat, drone.Position.Lon, en.Position.Lat, en.Position.Lon)
 		d := enemy.DetectionRow{
 			ClusterID:  s.clusterID,
 			DroneID:    drone.ID,
@@ -159,6 +164,12 @@ func (s *Simulator) processDetections(fleet *DroneFleet, drone *telemetry.Drone)
 			Lat:        en.Position.Lat,
 			Lon:        en.Position.Lon,
 			Alt:        en.Position.Alt,
+			DroneLat:   drone.Position.Lat,
+			DroneLon:   drone.Position.Lon,
+			DroneAlt:   drone.Position.Alt,
+			DistanceM:  dist,
+			BearingDeg: bearing,
+			EnemyVelMS: vel,
 			Confidence: conf,
 			Timestamp:  s.now().UTC(),
 		}

--- a/schemas/enemy_detection.cue
+++ b/schemas/enemy_detection.cue
@@ -1,0 +1,22 @@
+package schemas
+
+import "time"
+
+#Detection: {
+        cluster_id: string
+        drone_id:   string
+        enemy_id:   string
+        enemy_type: string
+        lat:        number
+        lon:        number
+        alt:        number
+        drone_lat:  number
+        drone_lon:  number
+        drone_alt:  number
+        distance_m: number
+        bearing_deg: number
+        enemy_velocity_mps: number
+        confidence: number & >=0 & <=100
+        ts:         time.Time
+}
+


### PR DESCRIPTION
## Summary
- capture drone coordinates, distance, bearing, and velocity in `DetectionRow`
- persist enriched detection data to GreptimeDB/JSONL via new detection writer interface
- document and visualise detection metrics with updated schema, docs, and Grafana panel

## Testing
- `go vet ./...`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688fba3ec6b08323a4d2c3a3f817f033