### PR TITLE
feat(sim): add swarm event telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It supports:
 - **Output to GreptimeDB** using its gRPC ORM interface **or** to STDOUT for quick demos
 - **Mission scenarios** scripted with a lightweight DSL for phases and enemy objectives
 - **Observer dashboard** for stepping through mission events, switching perspectives, and injecting commands
+- **Swarm-event logs** for follower assignments, reassignments, and formation changes
 
 This project was designed to support visualization dashboards (e.g., Grafana Geomap panel) and multi-cluster sync scenarios (mission clusters → command cluster).
 
@@ -76,6 +77,7 @@ The simulator can be configured through the following environment variables:
 | `GREPTIMEDB_ENDPOINT` | _none_ | Yes (for GreptimeDB) | GreptimeDB gRPC endpoint. If unset, telemetry is printed to STDOUT. |
 | `GREPTIMEDB_TABLE` | `drone_telemetry` | No | Table for drone telemetry records. |
 | `ENEMY_DETECTION_TABLE` | `enemy_detection` | No | Table storing enemy detection events. |
+| `SWARM_EVENT_TABLE` | `swarm_events` | No | Table storing swarm coordination events. |
 | `MISSION_METADATA_TABLE` | `mission_metadata` | No | Table storing mission metadata. |
 | `CLUSTER_ID` | `mission-01` | No | Cluster identity tag added to each telemetry line. |
 | `TICK_INTERVAL` | `1s` | No | Telemetry tick interval (Go duration). Overrides the `--tick` flag. |
@@ -87,6 +89,7 @@ See [docs/quickstart.md](docs/quickstart.md) for step-by-step instructions.
 ## Log Export & Playback
 
 - Use `--log-file` to export telemetry and enemy detection events as JSONL files.
+  Swarm coordination events are written to a `.swarm` companion file.
 - Replay a recorded mission:
 
 ```bash

--- a/docs/swarm-response.md
+++ b/docs/swarm-response.md
@@ -24,6 +24,10 @@ When several drones pursue a moving enemy, they no longer trail the target. Inst
 
 When drones peel off to pursue a target, the remaining units automatically reposition around the home region. This reconfiguration keeps surveillance coverage balanced by assigning new patrol points to the drones still in formation.
 
+## Swarm Event Telemetry
+
+Follower assignments, releases, and formation adjustments generate `swarm_event` records. Each event captures the affected drone IDs, related enemy, and a timestamp. These rows can be stored in GreptimeDB or written to JSONL logs for downstream analysis.
+
 ## Communication Constraints and Failover
 
 Swarms operate over lossy channels. The simulator can drop follow commands or telemetry updates based on a `communication_loss` probability and limits the number of commands per tick with `bandwidth_limit`. When a follower drops out or fails, the remaining drones reach consensus by selecting the highest-battery idle unit to take over tracking so priorities remain aligned despite signal issues.

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -348,6 +348,54 @@
         }
       ],
       "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "Follower Count",
+      "description": "Net follower assignments over time.",
+      "gridPos": { "x": 0, "y": 96, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "refId": "R",
+          "datasource": { "type": "greptimedb", "uid": "YOUR_GREPTIMEDB_UID" },
+          "rawSql": "SELECT $__timeGroupAlias(ts, 1m) AS time, SUM(CASE WHEN event_type='assignment' THEN 1 WHEN event_type='unassignment' THEN -1 ELSE 0 END) AS followers FROM swarm_events WHERE $__timeFilter(ts) AND cluster_id IN ($cluster_id) GROUP BY time ORDER BY time",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Reassignment Frequency",
+      "description": "Unassignment events per minute.",
+      "gridPos": { "x": 12, "y": 96, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "refId": "S",
+          "datasource": { "type": "greptimedb", "uid": "YOUR_GREPTIMEDB_UID" },
+          "rawSql": "SELECT $__timeGroupAlias(ts, 1m) AS time, COUNT(*) AS unassign FROM swarm_events WHERE $__timeFilter(ts) AND event_type='unassignment' AND cluster_id IN ($cluster_id) GROUP BY time ORDER BY time",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Formation Changes",
+      "description": "Formation reconfiguration events.",
+      "gridPos": { "x": 0, "y": 104, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "refId": "T",
+          "datasource": { "type": "greptimedb", "uid": "YOUR_GREPTIMEDB_UID" },
+          "rawSql": "SELECT $__timeGroupAlias(ts, 1m) AS time, COUNT(*) AS changes FROM swarm_events WHERE $__timeFilter(ts) AND event_type='formation_change' AND cluster_id IN ($cluster_id) GROUP BY time ORDER BY time",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] }
     }
   ],
   "templating": {

--- a/internal/sim/stdout_color_writer.go
+++ b/internal/sim/stdout_color_writer.go
@@ -139,3 +139,24 @@ func (w *ColorStdoutWriter) WriteDetections(rows []enemy.DetectionRow) error {
 	}
 	return nil
 }
+
+// WriteSwarmEvent prints a swarm coordination event to STDOUT.
+func (w *ColorStdoutWriter) WriteSwarmEvent(e telemetry.SwarmEventRow) error {
+	w.once.Do(w.printOverview)
+	fmt.Fprintf(w.out, "%s[%s]%s %sSWARM%s type=%s drones=%v",
+		colorGray, e.Timestamp.Format(time.RFC3339), colorReset,
+		colorCyan, colorReset, e.EventType, e.DroneIDs)
+	if e.EnemyID != "" {
+		fmt.Fprintf(w.out, " enemy=%s", e.EnemyID)
+	}
+	fmt.Fprintln(w.out)
+	return nil
+}
+
+// WriteSwarmEvents prints multiple swarm events.
+func (w *ColorStdoutWriter) WriteSwarmEvents(rows []telemetry.SwarmEventRow) error {
+	for _, e := range rows {
+		_ = w.WriteSwarmEvent(e)
+	}
+	return nil
+}

--- a/internal/sim/stdout_json_writer.go
+++ b/internal/sim/stdout_json_writer.go
@@ -49,3 +49,18 @@ func (w *JSONStdoutWriter) WriteDetections(rows []enemy.DetectionRow) error {
 	}
 	return nil
 }
+
+// WriteSwarmEvent outputs a swarm event in JSON format.
+func (w *JSONStdoutWriter) WriteSwarmEvent(e telemetry.SwarmEventRow) error {
+	data, _ := json.Marshal(e)
+	fmt.Fprintln(w.out, string(data))
+	return nil
+}
+
+// WriteSwarmEvents outputs multiple swarm events in JSON format.
+func (w *JSONStdoutWriter) WriteSwarmEvents(rows []telemetry.SwarmEventRow) error {
+	for _, r := range rows {
+		_ = w.WriteSwarmEvent(r)
+	}
+	return nil
+}

--- a/internal/sim/swarm_event_test.go
+++ b/internal/sim/swarm_event_test.go
@@ -1,0 +1,52 @@
+package sim
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"droneops-sim/internal/config"
+	"droneops-sim/internal/enemy"
+	"droneops-sim/internal/telemetry"
+)
+
+type mockSwarmWriter struct {
+	events []telemetry.SwarmEventRow
+}
+
+func (m *mockSwarmWriter) Write(row telemetry.TelemetryRow) error { return nil }
+func (m *mockSwarmWriter) WriteSwarmEvent(e telemetry.SwarmEventRow) error {
+	m.events = append(m.events, e)
+	return nil
+}
+
+// Ensure mock satisfies interfaces
+var _ TelemetryWriter = (*mockSwarmWriter)(nil)
+var _ SwarmEventWriter = (*mockSwarmWriter)(nil)
+
+func TestSimulator_AssignFollowerEmitsEvents(t *testing.T) {
+	cfg := &config.SimulationConfig{
+		Zones:    []config.Region{{Name: "region-1", CenterLat: 0, CenterLon: 0, RadiusKM: 10}},
+		Missions: []config.Mission{{ID: "m1", Name: "m1", Objective: "", Description: "", Region: config.Region{Name: "region-1", CenterLat: 0, CenterLon: 0, RadiusKM: 10}}},
+		Fleets:   []config.Fleet{{Name: "fleet", Model: "small-fpv", Count: 2, MovementPattern: "patrol", HomeRegion: "region-1", MissionID: "m1"}},
+	}
+	writer := &mockSwarmWriter{}
+	sim := NewSimulator("c1", cfg, writer, nil, time.Second, rand.New(rand.NewSource(1)), func() time.Time { return time.Unix(0, 0).UTC() })
+	fleet := &sim.fleets[0]
+	en := &enemy.Enemy{ID: "e1", Position: telemetry.Position{}}
+
+	sim.assignFollower(fleet, fleet.Drones[0], en, 95)
+
+	var hasAssign, hasFormation bool
+	for _, e := range writer.events {
+		switch e.EventType {
+		case telemetry.SwarmEventAssignment:
+			hasAssign = true
+		case telemetry.SwarmEventFormationChange:
+			hasFormation = true
+		}
+	}
+	if !hasAssign || !hasFormation {
+		t.Fatalf("expected assignment and formation events, got %#v", writer.events)
+	}
+}

--- a/internal/sim/swarm_writer.go
+++ b/internal/sim/swarm_writer.go
@@ -1,0 +1,13 @@
+package sim
+
+import "droneops-sim/internal/telemetry"
+
+// SwarmEventWriter handles swarm coordination events.
+type SwarmEventWriter interface {
+	WriteSwarmEvent(telemetry.SwarmEventRow) error
+}
+
+// Optional: writers may support batch mode for swarm events.
+type batchSwarmEventWriter interface {
+	WriteSwarmEvents([]telemetry.SwarmEventRow) error
+}

--- a/internal/telemetry/swarm_event.go
+++ b/internal/telemetry/swarm_event.go
@@ -1,0 +1,18 @@
+package telemetry
+
+import "time"
+
+const (
+	SwarmEventAssignment      = "assignment"
+	SwarmEventUnassignment    = "unassignment"
+	SwarmEventFormationChange = "formation_change"
+)
+
+// SwarmEventRow represents a swarm coordination event.
+type SwarmEventRow struct {
+	ClusterID string    `json:"cluster_id"`
+	EventType string    `json:"event_type"`
+	DroneIDs  []string  `json:"drone_ids"`
+	EnemyID   string    `json:"enemy_id,omitempty"`
+	Timestamp time.Time `json:"ts"`
+}

--- a/schemas/swarm_event.cue
+++ b/schemas/swarm_event.cue
@@ -1,0 +1,12 @@
+package schemas
+
+import "time"
+
+#SwarmEvent: {
+        cluster_id: string
+        event_type: string
+        drone_ids: [...string]
+        enemy_id?: string
+        ts: time.Time
+}
+


### PR DESCRIPTION
## Summary
- add `SwarmEventRow` type and schema for swarm coordination events
- emit swarm-event telemetry on follower assignment, release, and formation changes
- extend writers and Grafana dashboard to store and visualize swarm events

## Testing
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688fbe1c2500832390ba023f1147d536