### PR TITLE
feat: add movement telemetry metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ telemetry lines. Example mission record:
 Example drone telemetry line:
 
 ```json
-{"cluster_id":"mission-01","drone_id":"recon-swarm-204951-A","mission_id":"","lat":48.19985399217792,"lon":16.399831683018377,"alt":99.89517965510856,"battery":99.5,"status":"ok","synced_from":"","synced_id":"","synced_at":"0001-01-01T00:00:00Z","ts":"2025-07-29T20:49:52.332081195Z"}
+{"cluster_id":"mission-01","drone_id":"recon-swarm-204951-A","mission_id":"","lat":48.19985,"lon":16.39983,"alt":99.9,"battery":99.5,"status":"ok","movement_pattern":"patrol","speed_mps":12.3,"heading_deg":180,"previous_position":{"lat":48.19980,"lon":16.39980,"alt":100},"synced_from":"","synced_id":"","synced_at":"0001-01-01T00:00:00Z","ts":"2025-07-29T20:49:52.332081195Z"}
 ```
 
 ## Architecture

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,30 @@
+# Telemetry
+
+Drone telemetry rows include movement metadata to aid analysis and visualization.
+
+## Movement Fields
+
+- `movement_pattern` – current movement strategy (e.g., `patrol`, `point-to-point`, `loiter`).
+- `speed_mps` – speed in meters per second derived from the previous position.
+- `heading_deg` – bearing from the previous to the current position in degrees.
+- `previous_position` – last reported position `{lat, lon, alt}` used for delta calculations.
+
+These fields are emitted alongside existing telemetry attributes and are available in
+STDOUT, file logs and GreptimeDB outputs.
+
+```json
+{
+  "cluster_id": "mission-01",
+  "drone_id": "alpha-1",
+  "movement_pattern": "patrol",
+  "speed_mps": 14.2,
+  "heading_deg": 180.0,
+  "previous_position": {"lat": 48.2, "lon": 16.4, "alt": 100},
+  "lat": 48.3,
+  "lon": 16.5,
+  "alt": 100,
+  "battery": 99.5,
+  "status": "ok",
+  "ts": "2025-07-29T20:49:52Z"
+}
+```

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -396,6 +396,51 @@
         }
       ],
       "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 20,
+      "type": "piechart",
+      "title": "Movement Pattern Distribution",
+      "gridPos": { "x": 0, "y": 112, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "refId": "U",
+          "datasource": { "type": "greptimedb", "uid": "YOUR_GREPTIMEDB_UID" },
+          "rawSql": "SELECT movement_pattern, COUNT(*) as count FROM drone_telemetry WHERE $__timeFilter(ts) AND cluster_id IN ($cluster_id) GROUP BY movement_pattern",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Average Speed",
+      "gridPos": { "x": 12, "y": 112, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "refId": "V",
+          "datasource": { "type": "greptimedb", "uid": "YOUR_GREPTIMEDB_UID" },
+          "rawSql": "SELECT $__time(ts) AS time, AVG(speed_mps) AS speed FROM drone_telemetry WHERE $__timeFilter(ts) AND cluster_id IN ($cluster_id) GROUP BY time ORDER BY time",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 22,
+      "type": "histogram",
+      "title": "Heading Distribution",
+      "gridPos": { "x": 0, "y": 120, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "refId": "W",
+          "datasource": { "type": "greptimedb", "uid": "YOUR_GREPTIMEDB_UID" },
+          "rawSql": "SELECT heading_deg FROM drone_telemetry WHERE $__timeFilter(ts) AND cluster_id IN ($cluster_id)",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] }
     }
   ],
   "templating": {

--- a/grafana_dashboard_sling.json
+++ b/grafana_dashboard_sling.json
@@ -143,6 +143,42 @@
       "options": { "showHeader": true, "sortBy": [{ "displayName": "end_time", "desc": true }] },
       "fieldConfig": { "defaults": { "unit": "none" } },
       "gridPos": { "h": 10, "w": 24, "x": 0, "y": 35 }
+    },
+    {
+      "type": "piechart",
+      "title": "Movement Pattern Distribution",
+      "datasource": { "type": "postgres", "uid": "YOUR_DATASOURCE_UID" },
+      "targets": [
+        {
+          "rawSql": "SELECT movement_pattern, COUNT(*) AS count FROM drone_telemetry WHERE $__timeFilter(ts) AND ('$synced_from' = '' OR synced_from = '$synced_from') GROUP BY movement_pattern",
+          "refId": "B"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 45 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Average Speed",
+      "datasource": { "type": "postgres", "uid": "YOUR_DATASOURCE_UID" },
+      "targets": [
+        {
+          "rawSql": "SELECT $__time(ts) AS time, AVG(speed_mps) AS speed FROM drone_telemetry WHERE $__timeFilter(ts) AND ('$synced_from' = '' OR synced_from = '$synced_from') GROUP BY time ORDER BY time",
+          "refId": "C"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 45 }
+    },
+    {
+      "type": "histogram",
+      "title": "Heading Distribution",
+      "datasource": { "type": "postgres", "uid": "YOUR_DATASOURCE_UID" },
+      "targets": [
+        {
+          "rawSql": "SELECT heading_deg FROM drone_telemetry WHERE $__timeFilter(ts) AND ('$synced_from' = '' OR synced_from = '$synced_from')",
+          "refId": "D"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 45 }
     }
   ],
   "templating": {

--- a/internal/sim/greptime_writer.go
+++ b/internal/sim/greptime_writer.go
@@ -2,6 +2,7 @@ package sim
 
 import (
 	"context"
+	"encoding/json"
 	log "log/slog"
 	"strings"
 
@@ -77,12 +78,17 @@ func (w *GreptimeDBWriter) WriteBatch(rows []telemetry.TelemetryRow) error {
 	tbl.AddFieldColumn("alt", types.FLOAT64)
 	tbl.AddFieldColumn("battery", types.FLOAT64)
 	tbl.AddFieldColumn("status", types.STRING)
+	tbl.AddFieldColumn("movement_pattern", types.STRING)
+	tbl.AddFieldColumn("speed_mps", types.FLOAT64)
+	tbl.AddFieldColumn("heading_deg", types.FLOAT64)
+	tbl.AddFieldColumn("previous_position", types.STRING)
 	tbl.AddFieldColumn("synced_from", types.STRING)
 	tbl.AddFieldColumn("synced_id", types.STRING)
 	tbl.AddFieldColumn("synced_at", types.TIMESTAMP_MILLISECOND)
 	tbl.AddTimestampColumn("ts", types.TIMESTAMP_MILLISECOND)
 
 	for _, r := range rows {
+		prevJSON, _ := json.Marshal(r.PreviousPosition)
 		err := tbl.AddRow(
 			r.ClusterID,
 			r.DroneID,
@@ -91,6 +97,10 @@ func (w *GreptimeDBWriter) WriteBatch(rows []telemetry.TelemetryRow) error {
 			r.Alt,
 			r.Battery,
 			r.Status,
+			r.MovementPattern,
+			r.SpeedMPS,
+			r.HeadingDeg,
+			string(prevJSON),
 			r.SyncedFrom,
 			r.SyncedID,
 			r.SyncedAt,

--- a/internal/sim/simulator.go
+++ b/internal/sim/simulator.go
@@ -93,6 +93,7 @@ type Simulator struct {
 	swarmResponses       map[string]int
 	missionCriticality   int
 	enemyPrevPositions   map[string]telemetry.Position
+	dronePrevPositions   map[string]telemetry.Position
 	commLoss             float64
 	bandwidthLimit       int
 	messagesSent         int
@@ -167,6 +168,7 @@ func NewSimulator(clusterID string, cfg *config.SimulationConfig, writer Telemet
 		swarmResponses:       cfg.SwarmResponses,
 		missionCriticality:   crit,
 		enemyPrevPositions:   make(map[string]telemetry.Position),
+		dronePrevPositions:   make(map[string]telemetry.Position),
 		commLoss:             cfg.CommunicationLoss,
 		bandwidthLimit:       cfg.BandwidthLimit,
 		enemyFollowers:       make(map[string][]string),

--- a/internal/sim/simulator_test.go
+++ b/internal/sim/simulator_test.go
@@ -157,7 +157,7 @@ func TestInjectChaosAltersBattery(t *testing.T) {
 	}
 	sim := NewSimulator("cluster", cfg, &MockWriter{}, nil, time.Second, rand.New(rand.NewSource(1)), func() time.Time { return time.Unix(0, 0).UTC() })
 	drone := sim.fleets[0].Drones[0]
-	row := sim.teleGen.GenerateTelemetry(drone)
+	row := sim.teleGen.GenerateTelemetry(drone, drone.Position, time.Second)
 	before := drone.Battery
 	sim.injectChaos(drone, &row)
 	if drone.Battery >= before {

--- a/internal/sim/stdout_color_writer.go
+++ b/internal/sim/stdout_color_writer.go
@@ -104,6 +104,10 @@ func (w *ColorStdoutWriter) Write(row telemetry.TelemetryRow) error {
 	fmt.Fprintf(w.out, "%slon=%.5f%s ", colorYellow, row.Lon, colorReset)
 	fmt.Fprintf(w.out, "%salt=%.1f%s ", colorMagenta, row.Alt, colorReset)
 	fmt.Fprintf(w.out, "%sbatt=%.1f%s ", colorCyan, row.Battery, colorReset)
+	fmt.Fprintf(w.out, "%spattern=%s%s ", colorBlue, row.MovementPattern, colorReset)
+	fmt.Fprintf(w.out, "%sspd=%.1f%s ", colorYellow, row.SpeedMPS, colorReset)
+	fmt.Fprintf(w.out, "%shdg=%.1f%s ", colorCyan, row.HeadingDeg, colorReset)
+	fmt.Fprintf(w.out, "%sprev=(%.5f,%.5f,%.1f)%s ", colorGray, row.PreviousPosition.Lat, row.PreviousPosition.Lon, row.PreviousPosition.Alt, colorReset)
 	fmt.Fprintf(w.out, "%sstatus=%s%s", statusColor, row.Status, colorReset)
 	if row.Follow {
 		fmt.Fprintf(w.out, " %sfollow%s", colorMagenta, colorReset)

--- a/internal/telemetry/types.go
+++ b/internal/telemetry/types.go
@@ -17,19 +17,23 @@ type MissionRow struct {
 
 // TelemetryRow represents one telemetry record for GreptimeDB.
 type TelemetryRow struct {
-	ClusterID  string    `json:"cluster_id"`  // TAG
-	DroneID    string    `json:"drone_id"`    // TAG
-	MissionID  string    `json:"mission_id"`  // Added field for mission association
-	Lat        float64   `json:"lat"`         // FIELD
-	Lon        float64   `json:"lon"`         // FIELD
-	Alt        float64   `json:"alt"`         // FIELD
-	Battery    float64   `json:"battery"`     // FIELD
-	Status     string    `json:"status"`      // FIELD
-	Follow     bool      `json:"follow"`      // FIELD indicates active follow mode
-	SyncedFrom string    `json:"synced_from"` // Added by sync process
-	SyncedID   string    `json:"synced_id"`   // Added by sync process
-	SyncedAt   time.Time `json:"synced_at"`   // Added by sync process
-	Timestamp  time.Time `json:"ts"`          // TIME INDEX
+	ClusterID        string    `json:"cluster_id"`        // TAG
+	DroneID          string    `json:"drone_id"`          // TAG
+	MissionID        string    `json:"mission_id"`        // Added field for mission association
+	Lat              float64   `json:"lat"`               // FIELD
+	Lon              float64   `json:"lon"`               // FIELD
+	Alt              float64   `json:"alt"`               // FIELD
+	Battery          float64   `json:"battery"`           // FIELD
+	Status           string    `json:"status"`            // FIELD
+	Follow           bool      `json:"follow"`            // FIELD indicates active follow mode
+	MovementPattern  string    `json:"movement_pattern"`  // FIELD movement pattern
+	SpeedMPS         float64   `json:"speed_mps"`         // FIELD speed in meters/second
+	HeadingDeg       float64   `json:"heading_deg"`       // FIELD heading in degrees
+	PreviousPosition Position  `json:"previous_position"` // FIELD previous position
+	SyncedFrom       string    `json:"synced_from"`       // Added by sync process
+	SyncedID         string    `json:"synced_id"`         // Added by sync process
+	SyncedAt         time.Time `json:"synced_at"`         // Added by sync process
+	Timestamp        time.Time `json:"ts"`                // TIME INDEX
 }
 
 // TelemetryTableName holds the table name used when writing to GreptimeDB.

--- a/schemas/telemetry.cue
+++ b/schemas/telemetry.cue
@@ -1,0 +1,27 @@
+package schemas
+
+import "time"
+
+#Telemetry: {
+        cluster_id: string
+        drone_id: string
+        mission_id: string
+        lat: number
+        lon: number
+        alt: number
+        battery: number
+        status: string
+        follow: bool
+        movement_pattern: string
+        speed_mps: number
+        heading_deg: number
+        previous_position: {
+                lat: number
+                lon: number
+                alt: number
+        }
+        synced_from?: string
+        synced_id?: string
+        synced_at?: time.Time
+        ts: time.Time
+}


### PR DESCRIPTION
## Summary
- enrich telemetry with movement pattern, speed, heading, and previous position
- track per-drone history to compute deltas and expose new metrics across writers and dashboards
- document movement pattern telemetry and extend Grafana dashboards

## Testing
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689035f6e9788323a845622472bbbce2