### PR TITLE
feat: add simulation state telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It supports:
 - **Mission scenarios** scripted with a lightweight DSL for phases and enemy objectives
 - **Observer dashboard** for stepping through mission events, switching perspectives, and injecting commands
 - **Swarm-event logs** for follower assignments, reassignments, and formation changes
+- **Per-tick simulation state metrics** including communication reliability, sensor noise, weather impact, and chaos-mode status
 
 This project was designed to support visualization dashboards (e.g., Grafana Geomap panel) and multi-cluster sync scenarios (mission clusters → command cluster).
 
@@ -78,6 +79,7 @@ The simulator can be configured through the following environment variables:
 | `GREPTIMEDB_TABLE` | `drone_telemetry` | No | Table for drone telemetry records. |
 | `ENEMY_DETECTION_TABLE` | `enemy_detection` | No | Table storing enemy detection events. |
 | `SWARM_EVENT_TABLE` | `swarm_events` | No | Table storing swarm coordination events. |
+| `SIMULATION_STATE_TABLE` | `simulation_state` | No | Table storing per-tick simulation state metrics. |
 | `MISSION_METADATA_TABLE` | `mission_metadata` | No | Table storing mission metadata. |
 | `CLUSTER_ID` | `mission-01` | No | Cluster identity tag added to each telemetry line. |
 | `TICK_INTERVAL` | `1s` | No | Telemetry tick interval (Go duration). Overrides the `--tick` flag. |
@@ -213,6 +215,7 @@ The Grafana dashboard integrates mission data to provide:
 - **Mission Objectives**: Display the name, objective, and description.
 - **Region Visualization**: Overlay mission regions on the Geomap panel.
 - **Drone Telemetry**: Filter and group drones by mission.
+- **Simulation State Panels**: Track communication reliability, sensor noise trends, and chaos-mode indicators over time.
 
 ### Program Logic
 

--- a/cmd/droneops-sim/writer.go
+++ b/cmd/droneops-sim/writer.go
@@ -20,7 +20,7 @@ func newWriters(cfg *config.SimulationConfig, printOnly bool, logFile string) (s
 		return writer, detectWriter, cleanup, nil
 	}
 
-	fw, err := sim.NewFileWriter(logFile, logFile+".detections", logFile+".swarm")
+	fw, err := sim.NewFileWriter(logFile, logFile+".detections", logFile+".swarm", logFile+".state")
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -44,7 +44,8 @@ func baseWriters(cfg *config.SimulationConfig, printOnly bool) (sim.TelemetryWri
 	table := os.Getenv("GREPTIMEDB_TABLE")
 	detTable := os.Getenv("ENEMY_DETECTION_TABLE")
 	swarmTable := os.Getenv("SWARM_EVENT_TABLE")
-	w, err := sim.NewGreptimeDBWriter(endpoint, "public", table, detTable, swarmTable)
+	stateTable := os.Getenv("SIMULATION_STATE_TABLE")
+	w, err := sim.NewGreptimeDBWriter(endpoint, "public", table, detTable, swarmTable, stateTable)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/droneops-sim/writer_test.go
+++ b/cmd/droneops-sim/writer_test.go
@@ -54,11 +54,26 @@ func TestNewWritersLogFile(t *testing.T) {
 	if err := tw.Write(row); err != nil {
 		t.Fatalf("write failed: %v", err)
 	}
+	sw, ok := tw.(sim.StateWriter)
+	if !ok {
+		t.Fatalf("telemetry writer does not implement StateWriter")
+	}
+	st := telemetry.SimulationStateRow{ClusterID: "c1", CommunicationLoss: 0.1, MessagesSent: 1, SensorNoise: 0.2, WeatherImpact: 0.3, ChaosMode: true, Timestamp: time.Now()}
+	if err := sw.WriteState(st); err != nil {
+		t.Fatalf("write state failed: %v", err)
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("stat failed: %v", err)
 	}
 	if info.Size() == 0 {
 		t.Fatalf("expected log file to be non-empty")
+	}
+	stateInfo, err := os.Stat(path + ".state")
+	if err != nil {
+		t.Fatalf("stat state failed: %v", err)
+	}
+	if stateInfo.Size() == 0 {
+		t.Fatalf("expected state file to be non-empty")
 	}
 }

--- a/docs/demo-best-practices.md
+++ b/docs/demo-best-practices.md
@@ -14,6 +14,7 @@ Effective demos follow a clear story and highlight the simulator's strengths. Us
 ## Highlight Key Moments
 - Plan two or three inflection points such as enemy encounters, battery warnings, or mission updates.
 - Provide visual cues in Grafana or logs so each moment is easy to spot.
+- Use simulation state panels to call out communication reliability dips, rising sensor noise, or when chaos mode is enabled.
 
 ## Demonstrate Resilience
 - Include a failure or unexpected event and show how the system recovers.

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -441,6 +441,50 @@
         }
       ],
       "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 23,
+      "type": "timeseries",
+      "title": "Communication Reliability",
+      "gridPos": { "x": 0, "y": 128, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "refId": "X",
+          "datasource": { "type": "greptimedb", "uid": "YOUR_GREPTIMEDB_UID" },
+          "rawSql": "SELECT $__time(ts) AS time, 1 - communication_loss AS reliability FROM simulation_state WHERE $__timeFilter(ts) AND cluster_id IN ($cluster_id) ORDER BY time",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 24,
+      "type": "timeseries",
+      "title": "Sensor Noise",
+      "gridPos": { "x": 12, "y": 128, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "refId": "Y",
+          "datasource": { "type": "greptimedb", "uid": "YOUR_GREPTIMEDB_UID" },
+          "rawSql": "SELECT $__time(ts) AS time, sensor_noise FROM simulation_state WHERE $__timeFilter(ts) AND cluster_id IN ($cluster_id) ORDER BY time",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 25,
+      "type": "stat",
+      "title": "Chaos Mode",
+      "gridPos": { "x": 0, "y": 136, "w": 12, "h": 4 },
+      "targets": [
+        {
+          "refId": "Z",
+          "datasource": { "type": "greptimedb", "uid": "YOUR_GREPTIMEDB_UID" },
+          "rawSql": "SELECT chaos_mode FROM simulation_state WHERE $__timeFilter(ts) AND cluster_id IN ($cluster_id) ORDER BY ts DESC LIMIT 1",
+          "format": "table"
+        }
+      ]
     }
   ],
   "templating": {

--- a/grafana_dashboard_sling.json
+++ b/grafana_dashboard_sling.json
@@ -179,6 +179,42 @@
         }
       ],
       "gridPos": { "h": 8, "w": 8, "x": 16, "y": 45 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Communication Reliability",
+      "datasource": { "type": "postgres", "uid": "YOUR_DATASOURCE_UID" },
+      "targets": [
+        {
+          "rawSql": "SELECT $__time(ts) AS time, 1 - communication_loss AS reliability FROM simulation_state WHERE $__timeFilter(ts) ORDER BY time",
+          "refId": "E"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 53 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Sensor Noise",
+      "datasource": { "type": "postgres", "uid": "YOUR_DATASOURCE_UID" },
+      "targets": [
+        {
+          "rawSql": "SELECT $__time(ts) AS time, sensor_noise FROM simulation_state WHERE $__timeFilter(ts) ORDER BY time",
+          "refId": "F"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 53 }
+    },
+    {
+      "type": "stat",
+      "title": "Chaos Mode",
+      "datasource": { "type": "postgres", "uid": "YOUR_DATASOURCE_UID" },
+      "targets": [
+        {
+          "rawSql": "SELECT chaos_mode FROM simulation_state WHERE $__timeFilter(ts) ORDER BY ts DESC LIMIT 1",
+          "refId": "G"
+        }
+      ],
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 53 }
     }
   ],
   "templating": {

--- a/internal/sim/state_row_test.go
+++ b/internal/sim/state_row_test.go
@@ -1,0 +1,67 @@
+package sim
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"droneops-sim/internal/config"
+	"droneops-sim/internal/enemy"
+	"droneops-sim/internal/telemetry"
+)
+
+type MockStateWriter struct {
+	Rows []telemetry.SimulationStateRow
+}
+
+func (w *MockStateWriter) WriteState(r telemetry.SimulationStateRow) error {
+	w.Rows = append(w.Rows, r)
+	return nil
+}
+
+func (w *MockStateWriter) Write(telemetry.TelemetryRow) error { return nil }
+
+func TestSimulationStateEmission(t *testing.T) {
+	cfg := &config.SimulationConfig{
+		Zones:             []config.Region{{Name: "r1", CenterLat: 1, CenterLon: 2, RadiusKM: 1}},
+		Missions:          []config.Mission{{ID: "m1", Name: "m1", Objective: "", Description: "", Region: config.Region{Name: "r1", CenterLat: 1, CenterLon: 2, RadiusKM: 1}}},
+		Fleets:            []config.Fleet{{Name: "f1", Model: "small-fpv", Count: 1, MovementPattern: "patrol", HomeRegion: "r1", MissionID: "m1"}},
+		CommunicationLoss: 0.25,
+		SensorNoise:       0.1,
+		WeatherImpact:     0.2,
+	}
+	writer := &MockStateWriter{}
+	sim := NewSimulator("c1", cfg, writer, nil, time.Second, rand.New(rand.NewSource(1)), func() time.Time { return time.Unix(0, 0).UTC() })
+	sim.chaosMode = true
+	sim.enemyFollowerTargets["e1"] = 1
+	sim.enemyFollowers["e1"] = []string{}
+	sim.enemyObjects["e1"] = &enemy.Enemy{ID: "e1"}
+
+	sim.tick(context.Background())
+
+	if len(writer.Rows) != 1 {
+		t.Fatalf("expected 1 state row, got %d", len(writer.Rows))
+	}
+	r1 := writer.Rows[0]
+	if !r1.ChaosMode || r1.MessagesSent == 0 {
+		t.Fatalf("unexpected state row: %+v", r1)
+	}
+	if r1.CommunicationLoss != 0.25 || r1.SensorNoise != 0.1 || r1.WeatherImpact != 0.2 {
+		t.Fatalf("unexpected metrics: %+v", r1)
+	}
+
+	// second tick with chaos mode off and no messages
+	writer.Rows = nil
+	sim.chaosMode = false
+	delete(sim.enemyFollowerTargets, "e1")
+	delete(sim.enemyFollowers, "e1")
+	sim.tick(context.Background())
+	if len(writer.Rows) != 1 {
+		t.Fatalf("expected 1 state row, got %d", len(writer.Rows))
+	}
+	r2 := writer.Rows[0]
+	if r2.ChaosMode {
+		t.Fatalf("unexpected second state row: %+v", r2)
+	}
+}

--- a/internal/sim/state_writer.go
+++ b/internal/sim/state_writer.go
@@ -1,0 +1,13 @@
+package sim
+
+import "droneops-sim/internal/telemetry"
+
+// StateWriter handles simulation state rows.
+type StateWriter interface {
+	WriteState(telemetry.SimulationStateRow) error
+}
+
+// Optional: writers may support batch mode for state rows.
+type batchStateWriter interface {
+	WriteStates([]telemetry.SimulationStateRow) error
+}

--- a/internal/sim/stdout_color_writer.go
+++ b/internal/sim/stdout_color_writer.go
@@ -164,3 +164,21 @@ func (w *ColorStdoutWriter) WriteSwarmEvents(rows []telemetry.SwarmEventRow) err
 	}
 	return nil
 }
+
+// WriteState prints simulation state metrics to STDOUT.
+func (w *ColorStdoutWriter) WriteState(row telemetry.SimulationStateRow) error {
+	w.once.Do(w.printOverview)
+	fmt.Fprintf(w.out, "%s[%s]%s %sSTATE%s comm_loss=%.2f msgs=%d sensor_noise=%.2f weather=%.2f chaos=%t\n",
+		colorGray, row.Timestamp.Format(time.RFC3339), colorReset,
+		colorBlue, colorReset, row.CommunicationLoss, row.MessagesSent,
+		row.SensorNoise, row.WeatherImpact, row.ChaosMode)
+	return nil
+}
+
+// WriteStates prints multiple simulation state rows.
+func (w *ColorStdoutWriter) WriteStates(rows []telemetry.SimulationStateRow) error {
+	for _, r := range rows {
+		_ = w.WriteState(r)
+	}
+	return nil
+}

--- a/internal/sim/stdout_json_writer.go
+++ b/internal/sim/stdout_json_writer.go
@@ -64,3 +64,18 @@ func (w *JSONStdoutWriter) WriteSwarmEvents(rows []telemetry.SwarmEventRow) erro
 	}
 	return nil
 }
+
+// WriteState outputs a simulation state row in JSON format.
+func (w *JSONStdoutWriter) WriteState(row telemetry.SimulationStateRow) error {
+	data, _ := json.Marshal(row)
+	fmt.Fprintln(w.out, string(data))
+	return nil
+}
+
+// WriteStates outputs multiple simulation state rows in JSON format.
+func (w *JSONStdoutWriter) WriteStates(rows []telemetry.SimulationStateRow) error {
+	for _, r := range rows {
+		_ = w.WriteState(r)
+	}
+	return nil
+}

--- a/internal/sim/tick.go
+++ b/internal/sim/tick.go
@@ -92,6 +92,24 @@ func (s *Simulator) tick(ctx context.Context) {
 			}
 		}
 	}
+
+	// Emit simulation state metrics
+	if sw, ok := s.writer.(StateWriter); ok {
+		state := telemetry.SimulationStateRow{
+			ClusterID:         s.clusterID,
+			CommunicationLoss: s.commLoss,
+			MessagesSent:      s.messagesSent,
+			SensorNoise:       s.sensorNoise,
+			WeatherImpact:     s.weatherImpact,
+			ChaosMode:         s.chaosMode,
+			Timestamp:         s.now().UTC(),
+		}
+		if bw, ok := s.writer.(batchStateWriter); ok {
+			_ = bw.WriteStates([]telemetry.SimulationStateRow{state})
+		} else {
+			_ = sw.WriteState(state)
+		}
+	}
 }
 
 func (s *Simulator) updateDrone(drone *telemetry.Drone) (telemetry.TelemetryRow, bool) {

--- a/internal/telemetry/simulation_state.go
+++ b/internal/telemetry/simulation_state.go
@@ -1,0 +1,14 @@
+package telemetry
+
+import "time"
+
+// SimulationStateRow captures per-tick simulator state metrics.
+type SimulationStateRow struct {
+	ClusterID         string    `json:"cluster_id"`
+	CommunicationLoss float64   `json:"communication_loss"`
+	MessagesSent      int       `json:"messages_sent"`
+	SensorNoise       float64   `json:"sensor_noise"`
+	WeatherImpact     float64   `json:"weather_impact"`
+	ChaosMode         bool      `json:"chaos_mode"`
+	Timestamp         time.Time `json:"ts"`
+}

--- a/schemas/simulation_state.cue
+++ b/schemas/simulation_state.cue
@@ -1,0 +1,14 @@
+package schemas
+
+import "time"
+
+#SimulationState: {
+        cluster_id: string
+        communication_loss: number
+        messages_sent: int
+        sensor_noise: number
+        weather_impact: number
+        chaos_mode: bool
+        ts: time.Time
+}
+


### PR DESCRIPTION
## Summary
- add SimulationStateRow and emit it every tick
- support state writers in stdout, file, and GreptimeDB outputs
- document and visualize comms reliability, sensor noise, and chaos mode metrics

## Testing
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68903bdcaaa083239b1a8792b399792f