### PR TITLE
feat: add telemetry stream toggles

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ variables:
 test:
   stage: test
   script:
+    - cue vet config/simulation.yaml schemas/simulation.cue
     - go test ./...
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ The simulator can be configured through the following environment variables:
 | `MISSION_METADATA_TABLE` | `mission_metadata` | No | Table storing mission metadata. |
 | `CLUSTER_ID` | `mission-01` | No | Cluster identity tag added to each telemetry line. |
 | `TICK_INTERVAL` | `1s` | No | Telemetry tick interval (Go duration). Overrides the `--tick` flag. |
+| `ENABLE_DETECTIONS` | `true` | No | Toggle emission of enemy detection stream. |
+| `ENABLE_SWARM_EVENTS` | `true` | No | Toggle emission of swarm event stream. |
+| `ENABLE_MOVEMENT_METRICS` | `true` | No | Toggle emission of movement telemetry. |
+| `ENABLE_SIMULATION_STATE` | `true` | No | Toggle emission of simulation state stream. |
 
 ## Quickstart
 

--- a/cmd/droneops-sim/writer_test.go
+++ b/cmd/droneops-sim/writer_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNewWritersPrintOnly(t *testing.T) {
-	tw, dw, cleanup, err := newWriters(nil, true, "")
+	tw, dw, cleanup, err := newWriters(nil, true, "", true, true, true)
 	if err != nil {
 		t.Fatalf("newWriters returned error: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestNewWritersPrintOnly(t *testing.T) {
 
 func TestNewWritersGreptimeFallback(t *testing.T) {
 	t.Setenv("GREPTIMEDB_ENDPOINT", "")
-	tw, dw, cleanup, err := newWriters(nil, false, "")
+	tw, dw, cleanup, err := newWriters(nil, false, "", true, true, true)
 	if err != nil {
 		t.Fatalf("newWriters returned error: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestNewWritersGreptimeFallback(t *testing.T) {
 func TestNewWritersLogFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "telemetry.log")
-	tw, _, cleanup, err := newWriters(nil, true, path)
+	tw, _, cleanup, err := newWriters(nil, true, path, true, true, true)
 	if err != nil {
 		t.Fatalf("newWriters returned error: %v", err)
 	}
@@ -75,5 +75,19 @@ func TestNewWritersLogFile(t *testing.T) {
 	}
 	if stateInfo.Size() == 0 {
 		t.Fatalf("expected state file to be non-empty")
+	}
+}
+
+func TestNewWritersDisableDetections(t *testing.T) {
+	tw, dw, cleanup, err := newWriters(nil, true, "", false, true, true)
+	if err != nil {
+		t.Fatalf("newWriters returned error: %v", err)
+	}
+	cleanup()
+	if dw != nil {
+		t.Fatalf("expected detection writer to be nil when disabled")
+	}
+	if _, ok := tw.(*sim.JSONStdoutWriter); !ok {
+		t.Fatalf("expected *sim.JSONStdoutWriter, got %T", tw)
 	}
 }

--- a/config/simulation.yaml
+++ b/config/simulation.yaml
@@ -94,3 +94,9 @@ terrain_occlusion: 0.1
 weather_impact: 0.2
 communication_loss: 0.05
 bandwidth_limit: 10
+
+telemetry:
+  detections: true
+  swarm_events: true
+  movement_metrics: true
+  simulation_state: true

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,6 +15,12 @@ make run
 export GREPTIMEDB_ENDPOINT=127.0.0.1:4001
 export GREPTIMEDB_TABLE=drone_telemetry
 export ENEMY_DETECTION_TABLE=enemy_detection
+export SWARM_EVENT_TABLE=swarm_events
+export SIMULATION_STATE_TABLE=simulation_state
+export ENABLE_DETECTIONS=true
+export ENABLE_SWARM_EVENTS=true
+export ENABLE_MOVEMENT_METRICS=true
+export ENABLE_SIMULATION_STATE=true
 ./build/droneops-sim simulate
 ```
 
@@ -26,6 +32,14 @@ docker run --rm \
     -e GREPTIMEDB_ENDPOINT=127.0.0.1:4001 \
     -e GREPTIMEDB_TABLE=drone_telemetry \
     -e ENEMY_DETECTION_TABLE=enemy_detection \
+    -e SWARM_EVENT_TABLE=swarm_events \
+    -e SIMULATION_STATE_TABLE=simulation_state \
+    -e ENABLE_DETECTIONS=true \
+    -e ENABLE_SWARM_EVENTS=true \
+    -e ENABLE_MOVEMENT_METRICS=true \
+    -e ENABLE_SIMULATION_STATE=true \
     droneops-sim:latest simulate
 ```
+
+To disable specific streams, pass flags such as `--detections=false` or `--simulation-state=false` to the `simulate` command.
 

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -485,6 +485,66 @@
           "format": "table"
         }
       ]
+    },
+    {
+      "id": 26,
+      "type": "timeseries",
+      "title": "Detections per Minute",
+      "gridPos": { "x": 0, "y": 140, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "refId": "AA",
+          "datasource": { "type": "greptimedb", "uid": "YOUR_GREPTIMEDB_UID" },
+          "rawSql": "SELECT $__timeGroupAlias(ts,1m) AS time, COUNT(*) AS detections FROM enemy_detection WHERE $__timeFilter(ts) AND cluster_id IN ($cluster_id) GROUP BY time ORDER BY time",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 27,
+      "type": "timeseries",
+      "title": "Swarm Assignments",
+      "gridPos": { "x": 12, "y": 140, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "refId": "AB",
+          "datasource": { "type": "greptimedb", "uid": "YOUR_GREPTIMEDB_UID" },
+          "rawSql": "SELECT $__timeGroupAlias(ts,1m) AS time, COUNT(*) AS assignments FROM swarm_events WHERE $__timeFilter(ts) AND event_type='assignment' AND cluster_id IN ($cluster_id) GROUP BY time ORDER BY time",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 28,
+      "type": "timeseries",
+      "title": "Average Speed",
+      "gridPos": { "x": 0, "y": 148, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "refId": "AC",
+          "datasource": { "type": "greptimedb", "uid": "YOUR_GREPTIMEDB_UID" },
+          "rawSql": "SELECT $__timeGroupAlias(ts,1m) AS time, AVG(speed_mps) AS speed FROM drone_telemetry WHERE $__timeFilter(ts) AND cluster_id IN ($cluster_id) GROUP BY time ORDER BY time",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 29,
+      "type": "timeseries",
+      "title": "Messages Sent",
+      "gridPos": { "x": 12, "y": 148, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "refId": "AD",
+          "datasource": { "type": "greptimedb", "uid": "YOUR_GREPTIMEDB_UID" },
+          "rawSql": "SELECT $__timeGroupAlias(ts,1m) AS time, AVG(messages_sent) AS msgs FROM simulation_state WHERE $__timeFilter(ts) AND cluster_id IN ($cluster_id) GROUP BY time ORDER BY time",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": { "defaults": {}, "overrides": [] }
     }
   ],
   "templating": {

--- a/helm/droneops-sim/templates/deployment.yaml
+++ b/helm/droneops-sim/templates/deployment.yaml
@@ -31,6 +31,18 @@ spec:
           value: "drone_telemetry"
         - name: ENEMY_DETECTION_TABLE
           value: "enemy_detection"
+        - name: SWARM_EVENT_TABLE
+          value: "swarm_events"
+        - name: SIMULATION_STATE_TABLE
+          value: "simulation_state"
+        - name: ENABLE_DETECTIONS
+          value: "true"
+        - name: ENABLE_SWARM_EVENTS
+          value: "true"
+        - name: ENABLE_MOVEMENT_METRICS
+          value: "true"
+        - name: ENABLE_SIMULATION_STATE
+          value: "true"
         - name: CLUSTER_ID
           value: "mission-01"
         volumeMounts:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,21 +51,30 @@ type Mission struct {
 	Region      Region `yaml:"region"`
 }
 
+// TelemetryToggles controls emission of telemetry streams.
+type TelemetryToggles struct {
+	Detections      *bool `yaml:"detections"`
+	SwarmEvents     *bool `yaml:"swarm_events"`
+	MovementMetrics *bool `yaml:"movement_metrics"`
+	SimulationState *bool `yaml:"simulation_state"`
+}
+
 // SimulationConfig is the root configuration for zones, missions, and fleets
 type SimulationConfig struct {
-	Zones              []Region       `yaml:"zones"`
-	Missions           []Mission      `yaml:"missions"`
-	Fleets             []Fleet        `yaml:"fleets"`
-	EnemyCount         int            `yaml:"enemy_count"`
-	DetectionRadiusM   float64        `yaml:"detection_radius_m"`
-	SensorNoise        float64        `yaml:"sensor_noise"`
-	TerrainOcclusion   float64        `yaml:"terrain_occlusion"`
-	WeatherImpact      float64        `yaml:"weather_impact"`
-	FollowConfidence   float64        `yaml:"follow_confidence"`
-	SwarmResponses     map[string]int `yaml:"swarm_responses"`
-	MissionCriticality string         `yaml:"mission_criticality"`
-	CommunicationLoss  float64        `yaml:"communication_loss"`
-	BandwidthLimit     int            `yaml:"bandwidth_limit"`
+	Zones              []Region         `yaml:"zones"`
+	Missions           []Mission        `yaml:"missions"`
+	Fleets             []Fleet          `yaml:"fleets"`
+	EnemyCount         int              `yaml:"enemy_count"`
+	DetectionRadiusM   float64          `yaml:"detection_radius_m"`
+	SensorNoise        float64          `yaml:"sensor_noise"`
+	TerrainOcclusion   float64          `yaml:"terrain_occlusion"`
+	WeatherImpact      float64          `yaml:"weather_impact"`
+	FollowConfidence   float64          `yaml:"follow_confidence"`
+	SwarmResponses     map[string]int   `yaml:"swarm_responses"`
+	MissionCriticality string           `yaml:"mission_criticality"`
+	CommunicationLoss  float64          `yaml:"communication_loss"`
+	BandwidthLimit     int              `yaml:"bandwidth_limit"`
+	Telemetry          TelemetryToggles `yaml:"telemetry"`
 }
 
 // Load loads YAML config and validates it against a CUE schema
@@ -83,6 +92,17 @@ func Load(configPath, cueSchemaPath string) (*SimulationConfig, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
+
+	setDefault := func(b **bool) {
+		if *b == nil {
+			v := true
+			*b = &v
+		}
+	}
+	setDefault(&cfg.Telemetry.Detections)
+	setDefault(&cfg.Telemetry.SwarmEvents)
+	setDefault(&cfg.Telemetry.MovementMetrics)
+	setDefault(&cfg.Telemetry.SimulationState)
 
 	log.Info("Loaded configuration", "config", cfg)
 

--- a/internal/sim/followers.go
+++ b/internal/sim/followers.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *Simulator) logSwarmEvent(eventType string, drones []string, enemyID string) {
-	if len(drones) == 0 {
+	if len(drones) == 0 || !s.enableSwarmEvents {
 		return
 	}
 	w, ok := s.writer.(SwarmEventWriter)

--- a/schemas/simulation.cue
+++ b/schemas/simulation.cue
@@ -53,3 +53,10 @@ terrain_occlusion?:  number & >=0 & <=1
 weather_impact?:     number & >=0 & <=1
 communication_loss?: number & >=0 & <=1
 bandwidth_limit?:    int & >=0
+
+telemetry?: {
+        detections?:      bool | *true
+        swarm_events?:    bool | *true
+        movement_metrics?: bool | *true
+        simulation_state?: bool | *true
+}

--- a/sling-sync-cronjob.yaml
+++ b/sling-sync-cronjob.yaml
@@ -16,6 +16,12 @@ spec:
             env:
             - name: MISSION_CLUSTER_ID
               value: "mission-01"
+            - name: ENEMY_DETECTION_TABLE
+              value: "enemy_detection"
+            - name: SWARM_EVENT_TABLE
+              value: "swarm_events"
+            - name: SIMULATION_STATE_TABLE
+              value: "simulation_state"
             - name: SYNC_JOB_ID
               valueFrom:
                 fieldRef:
@@ -41,9 +47,9 @@ data:
       table: drone_telemetry
       incremental_column: ts
 
-    target:
-      type: postgres
-      connection: "postgres://user:pass@command-db:5432/dbname"
+      target:
+        type: postgres
+        connection: "postgres://user:pass@command-db:5432/dbname"
       table: drone_telemetry
 
     transforms:
@@ -56,6 +62,51 @@ data:
       - add_column:
           name: synced_id
           value: "{{ env.SYNC_JOB_ID }}"
+
+    options:
+      on_conflict: skip
+
+  enemy-detection-sling.yaml: |
+    source:
+      type: postgres
+      connection: "postgres://user:pass@mission-db:5432/dbname"
+      table: enemy_detection
+      incremental_column: ts
+
+    target:
+      type: postgres
+      connection: "postgres://user:pass@command-db:5432/dbname"
+      table: enemy_detection
+
+    options:
+      on_conflict: skip
+
+  swarm-events-sling.yaml: |
+    source:
+      type: postgres
+      connection: "postgres://user:pass@mission-db:5432/dbname"
+      table: swarm_events
+      incremental_column: ts
+
+    target:
+      type: postgres
+      connection: "postgres://user:pass@command-db:5432/dbname"
+      table: swarm_events
+
+    options:
+      on_conflict: skip
+
+  simulation-state-sling.yaml: |
+    source:
+      type: postgres
+      connection: "postgres://user:pass@mission-db:5432/dbname"
+      table: simulation_state
+      incremental_column: ts
+
+    target:
+      type: postgres
+      connection: "postgres://user:pass@command-db:5432/dbname"
+      table: simulation_state
 
     options:
       on_conflict: skip


### PR DESCRIPTION
## Summary
- add config and schema toggles for detection, swarm, movement, and state streams
- wire CLI flags, env vars, and simulator logic to control telemetry
- expose new streams in Helm, cronjob, and Grafana dashboard

## Testing
- `cue vet config/simulation.yaml schemas/simulation.cue`
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689043b5c22c8323b9f0c2037bf8daff