### PR TITLE
feat(sim): add mission and follow to telemetry writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ telemetry lines. Example mission record:
 Example drone telemetry line:
 
 ```json
-{"cluster_id":"mission-01","drone_id":"recon-swarm-204951-A","mission_id":"","lat":48.19985,"lon":16.39983,"alt":99.9,"battery":99.5,"status":"ok","movement_pattern":"patrol","speed_mps":12.3,"heading_deg":180,"previous_position":{"lat":48.19980,"lon":16.39980,"alt":100},"synced_from":"","synced_id":"","synced_at":"0001-01-01T00:00:00Z","ts":"2025-07-29T20:49:52.332081195Z"}
+{"cluster_id":"mission-01","drone_id":"recon-swarm-204951-A","mission_id":"m1","lat":48.19985,"lon":16.39983,"alt":99.9,"battery":99.5,"status":"ok","follow":false,"movement_pattern":"patrol","speed_mps":12.3,"heading_deg":180,"previous_position":{"lat":48.19980,"lon":16.39980,"alt":100},"synced_from":"","synced_id":"","synced_at":"0001-01-01T00:00:00Z","ts":"2025-07-29T20:49:52.332081195Z"}
 ```
 
 ## Architecture

--- a/docs/enemy-detection.md
+++ b/docs/enemy-detection.md
@@ -23,7 +23,7 @@ grouping, and decoy tactics. A detection event is emitted whenever a drone is wi
 The event structure is defined in `internal/enemy/types.go` and now also includes the detecting drone's
 coordinates, distance to the target, relative bearing, and estimated enemy velocity in meters per second.
 
-Drone telemetry rows now include a `follow` field indicating whether the drone is actively tracking a target.
+Drone telemetry rows now include a `mission_id` tag and a `follow` field indicating whether the drone is actively tracking a target.
 
 ### Detection Event Fields
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry
 
-Drone telemetry rows include movement metadata to aid analysis and visualization.
+Drone telemetry rows include mission tags and movement metadata to aid analysis and visualization.
 
 ## Movement Fields
 
@@ -9,13 +9,14 @@ Drone telemetry rows include movement metadata to aid analysis and visualization
 - `heading_deg` – bearing from the previous to the current position in degrees.
 - `previous_position` – last reported position `{lat, lon, alt}` used for delta calculations.
 
-These fields are emitted alongside existing telemetry attributes and are available in
-STDOUT, file logs and GreptimeDB outputs.
+These fields are emitted alongside existing telemetry attributes such as the `mission_id`
+tag and `follow` state and are available in STDOUT, file logs and GreptimeDB outputs.
 
 ```json
-{
+{ 
   "cluster_id": "mission-01",
   "drone_id": "alpha-1",
+  "mission_id": "m1",
   "movement_pattern": "patrol",
   "speed_mps": 14.2,
   "heading_deg": 180.0,
@@ -25,6 +26,7 @@ STDOUT, file logs and GreptimeDB outputs.
   "alt": 100,
   "battery": 99.5,
   "status": "ok",
+  "follow": false,
   "ts": "2025-07-29T20:49:52Z"
 }
 ```

--- a/internal/sim/greptime_writer.go
+++ b/internal/sim/greptime_writer.go
@@ -78,11 +78,13 @@ func (w *GreptimeDBWriter) WriteBatch(rows []telemetry.TelemetryRow) error {
 	}
 	tbl.AddTagColumn("cluster_id", types.STRING)
 	tbl.AddTagColumn("drone_id", types.STRING)
+	tbl.AddTagColumn("mission_id", types.STRING)
 	tbl.AddFieldColumn("lat", types.FLOAT64)
 	tbl.AddFieldColumn("lon", types.FLOAT64)
 	tbl.AddFieldColumn("alt", types.FLOAT64)
 	tbl.AddFieldColumn("battery", types.FLOAT64)
 	tbl.AddFieldColumn("status", types.STRING)
+	tbl.AddFieldColumn("follow", types.BOOLEAN)
 	tbl.AddFieldColumn("movement_pattern", types.STRING)
 	tbl.AddFieldColumn("speed_mps", types.FLOAT64)
 	tbl.AddFieldColumn("heading_deg", types.FLOAT64)
@@ -97,11 +99,13 @@ func (w *GreptimeDBWriter) WriteBatch(rows []telemetry.TelemetryRow) error {
 		err := tbl.AddRow(
 			r.ClusterID,
 			r.DroneID,
+			r.MissionID,
 			r.Lat,
 			r.Lon,
 			r.Alt,
 			r.Battery,
 			r.Status,
+			r.Follow,
 			r.MovementPattern,
 			r.SpeedMPS,
 			r.HeadingDeg,


### PR DESCRIPTION
## Summary
- add `mission_id` tag and `follow` field to Greptime telemetry writer
- document mission and follow fields in telemetry and detection docs
- update example telemetry line in README

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6890825574288323acf219f366850246