### PR TITLE
fix(sim): log swarm event write errors

### DIFF
--- a/internal/sim/followers.go
+++ b/internal/sim/followers.go
@@ -1,6 +1,7 @@
 package sim
 
 import (
+	log "log/slog"
 	"math"
 
 	"droneops-sim/internal/enemy"
@@ -22,7 +23,9 @@ func (s *Simulator) logSwarmEvent(eventType string, drones []string, enemyID str
 		EnemyID:   enemyID,
 		Timestamp: s.now(),
 	}
-	_ = w.WriteSwarmEvent(row)
+	if err := w.WriteSwarmEvent(row); err != nil {
+		log.Error("swarm event write failed", "err", err)
+	}
 }
 
 func droneIDSlice(ds []*telemetry.Drone) []string {


### PR DESCRIPTION
## Summary
- log swarm event writes so errors are not silently ignored

## Testing
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6890908f36dc8323ba00d2fc0b9eab05