### PR TITLE
feat(tui): add enemy telemetry section and spawn dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It supports:
 - **Observer dashboard** for stepping through mission events, switching perspectives, and injecting commands
 - **Swarm-event logs** for follower assignments, reassignments, and formation changes
 - **Per-tick simulation state metrics** including communication reliability, sensor noise, weather impact, and chaos-mode status
+- **Interactive TUI** with hotkeys (`q` quit, `w` wrap, `s` scroll, `e` spawn enemy via `type,lat,lon,alt` + `Enter`; dialog auto-fills near the latest drone position for quick spawning)
 
 This project was designed to support visualization dashboards (e.g., Grafana Geomap panel) and multi-cluster sync scenarios (mission clusters → command cluster).
 

--- a/cmd/droneops-sim/simulate.go
+++ b/cmd/droneops-sim/simulate.go
@@ -95,6 +95,9 @@ var simulateCmd = &cobra.Command{
 		defer cancel()
 
 		simulator := sim.NewSimulator(clusterID, cfg, writer, detectWriter, tickInterval, nil, nil)
+		if sp, ok := writer.(sim.EnemySpawner); ok {
+			sp.SetSpawner(simulator.SpawnEnemy)
+		}
 
 		srv := admin.NewServer(simulator)
 		if aw, ok := writer.(sim.AdminStatusWriter); ok {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=

--- a/internal/sim/multi_writer.go
+++ b/internal/sim/multi_writer.go
@@ -142,6 +142,15 @@ func (mw *MultiWriter) SetAdminStatus(active bool) {
 	}
 }
 
+// SetSpawner forwards enemy spawn callbacks to writers that support it.
+func (mw *MultiWriter) SetSpawner(fn func(enemy.Enemy)) {
+	for _, w := range mw.telewriters {
+		if sp, ok := w.(EnemySpawner); ok {
+			sp.SetSpawner(fn)
+		}
+	}
+}
+
 // Close closes underlying writers that support it.
 func (mw *MultiWriter) Close() error {
 	for _, w := range mw.telewriters {

--- a/internal/sim/multi_writer_test.go
+++ b/internal/sim/multi_writer_test.go
@@ -1,0 +1,22 @@
+package sim
+
+import (
+	"testing"
+
+	"droneops-sim/internal/enemy"
+	"droneops-sim/internal/telemetry"
+)
+
+type stubSpawnWriter struct{ fn func(enemy.Enemy) }
+
+func (s *stubSpawnWriter) Write(telemetry.TelemetryRow) error { return nil }
+func (s *stubSpawnWriter) SetSpawner(f func(enemy.Enemy))     { s.fn = f }
+
+func TestMultiWriterSetSpawner(t *testing.T) {
+	s := &stubSpawnWriter{}
+	mw := NewMultiWriter([]TelemetryWriter{s}, nil, nil)
+	mw.SetSpawner(func(enemy.Enemy) {})
+	if s.fn == nil {
+		t.Fatalf("spawner not forwarded")
+	}
+}

--- a/internal/sim/simulator.go
+++ b/internal/sim/simulator.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+
 	"droneops-sim/internal/config"
 	"droneops-sim/internal/enemy"
 	"droneops-sim/internal/telemetry"
@@ -272,6 +274,23 @@ func NewSimulator(clusterID string, cfg *config.SimulationConfig, writer Telemet
 	sim.enemyEng = enemy.NewEngine(count, regions, r)
 
 	return sim
+}
+
+// SpawnEnemy adds a new enemy to the simulation.
+func (s *Simulator) SpawnEnemy(en enemy.Enemy) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.enemyEng == nil {
+		s.enemyEng = enemy.NewEngine(0, nil, s.rand)
+	}
+	if en.ID == "" {
+		en.ID = uuid.New().String()
+	}
+	s.enemyEng.Enemies = append(s.enemyEng.Enemies, &en)
+	if s.enemyObjects == nil {
+		s.enemyObjects = make(map[string]*enemy.Enemy)
+	}
+	s.enemyObjects[en.ID] = &en
 }
 
 // ToggleChaos flips chaos mode on or off and returns the new state.

--- a/internal/sim/simulator_test.go
+++ b/internal/sim/simulator_test.go
@@ -955,3 +955,11 @@ func TestProcessDetectionsPopulatesFields(t *testing.T) {
 		t.Fatalf("velocity mismatch: got %f want %f", det.EnemyVelMS, expVel)
 	}
 }
+
+func TestSimulatorSpawnEnemy(t *testing.T) {
+	sim := &Simulator{rand: rand.New(rand.NewSource(1))}
+	sim.SpawnEnemy(enemy.Enemy{Type: enemy.EnemyPerson, Position: telemetry.Position{Lat: 1, Lon: 2, Alt: 3}})
+	if sim.enemyEng == nil || len(sim.enemyEng.Enemies) != 1 {
+		t.Fatalf("expected enemy to be spawned")
+	}
+}

--- a/internal/sim/spawner.go
+++ b/internal/sim/spawner.go
@@ -1,0 +1,8 @@
+package sim
+
+import "droneops-sim/internal/enemy"
+
+// EnemySpawner allows setting a callback used to spawn enemies.
+type EnemySpawner interface {
+	SetSpawner(func(enemy.Enemy))
+}

--- a/internal/sim/tui_writer_test.go
+++ b/internal/sim/tui_writer_test.go
@@ -1,6 +1,7 @@
 package sim
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -26,22 +27,25 @@ func TestTUIWriterMessages(t *testing.T) {
 	if _, ok := p.msgs[0].(logMsg); !ok {
 		t.Fatalf("expected logMsg, got %T", p.msgs[0])
 	}
+	if _, ok := p.msgs[1].(telemetryMsg); !ok {
+		t.Fatalf("expected telemetryMsg, got %T", p.msgs[1])
+	}
 	st := telemetry.SimulationStateRow{MessagesSent: 1}
 	if err := w.WriteState(st); err != nil {
 		t.Fatalf("state: %v", err)
 	}
-	if _, ok := p.msgs[1].(stateMsg); !ok {
-		t.Fatalf("expected stateMsg, got %T", p.msgs[1])
+	if _, ok := p.msgs[2].(stateMsg); !ok {
+		t.Fatalf("expected stateMsg, got %T", p.msgs[2])
 	}
 	w.SetAdminStatus(true)
-	if _, ok := p.msgs[2].(adminMsg); !ok {
-		t.Fatalf("expected adminMsg, got %T", p.msgs[2])
+	if _, ok := p.msgs[3].(adminMsg); !ok {
+		t.Fatalf("expected adminMsg, got %T", p.msgs[3])
 	}
 	d := enemy.DetectionRow{DroneID: "d", EnemyID: "e", Timestamp: time.Unix(0, 0).UTC()}
 	if err := w.WriteDetection(d); err != nil {
 		t.Fatalf("detect: %v", err)
 	}
-	if _, ok := p.msgs[3].(logMsg); !ok {
+	if _, ok := p.msgs[4].(logMsg); !ok {
 		t.Fatalf("expected logMsg for detection")
 	}
 }
@@ -116,5 +120,98 @@ func TestScrollToggle(t *testing.T) {
 	expected = len(m.logs) - m.vp.Height
 	if m.vp.YOffset != expected {
 		t.Fatalf("expected YOffset %d after new log, got %d", expected, m.vp.YOffset)
+	}
+}
+
+func TestEnemySpawn(t *testing.T) {
+	cfg := &config.SimulationConfig{}
+	m := newTUIModel(cfg, nil)
+	m.spawn = func(enemy.Enemy) {}
+	// provide last known drone position
+	mi, _ := m.Update(telemetryMsg{telemetry.TelemetryRow{Lat: 1, Lon: 2, Alt: 3}})
+	m = mi.(tuiModel)
+	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	m = mi.(tuiModel)
+	if !m.enemyDialog {
+		t.Fatalf("expected enemy dialog to open")
+	}
+	expected := fmt.Sprintf("vehicle,%.5f,%.5f,%.1f", 1+enemyOffset, 2+enemyOffset, 3.0)
+	if m.enemyInput.Value() != expected {
+		t.Fatalf("expected default input %q, got %q", expected, m.enemyInput.Value())
+	}
+	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = mi.(tuiModel)
+	if len(m.enemies) != 1 {
+		t.Fatalf("expected enemy added")
+	}
+	en := m.enemies[0]
+	if en.Type != enemy.EnemyVehicle || en.Position.Lat != 1+enemyOffset || en.Position.Lon != 2+enemyOffset || en.Position.Alt != 3 {
+		t.Fatalf("unexpected enemy spawned: %+v", en)
+	}
+}
+
+func TestEnemySpawnFallback(t *testing.T) {
+	cfg := &config.SimulationConfig{}
+	m := newTUIModel(cfg, nil)
+	m.spawn = func(enemy.Enemy) {}
+	mi, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	m = mi.(tuiModel)
+	if m.enemyInput.Value() != fallbackEnemyInput {
+		t.Fatalf("expected fallback input %q, got %q", fallbackEnemyInput, m.enemyInput.Value())
+	}
+}
+
+func TestEnemySpawnNonBlocking(t *testing.T) {
+	cfg := &config.SimulationConfig{}
+	m := newTUIModel(cfg, nil)
+	start := make(chan struct{})
+	block := make(chan struct{})
+	m.spawn = func(enemy.Enemy) {
+		close(start)
+		<-block
+	}
+	m.enemyDialog = true
+	m.enemyInput.SetValue(fallbackEnemyInput)
+	done := make(chan struct{})
+	go func() {
+		mi, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		m = mi.(tuiModel)
+		close(done)
+	}()
+	<-start
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("update blocked when spawn callback is slow")
+	}
+	if len(m.enemies) != 1 {
+		t.Fatalf("expected enemy added")
+	}
+	if m.enemyDialog {
+		t.Fatalf("expected enemy dialog closed")
+	}
+	close(block)
+}
+
+func TestEnemySpawnHint(t *testing.T) {
+	cfg := &config.SimulationConfig{}
+	m := newTUIModel(cfg, nil)
+	mi, _ := m.Update(telemetryMsg{telemetry.TelemetryRow{Lat: 4, Lon: 5, Alt: 6}})
+	m = mi.(tuiModel)
+	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	m = mi.(tuiModel)
+	hint := m.renderEnemies()
+	if !strings.Contains(hint, "type,lat,lon,alt") {
+		t.Fatalf("expected input format hint, got %q", hint)
+	}
+	if !strings.Contains(hint, "Enter to spawn") {
+		t.Fatalf("expected Enter instruction, got %q", hint)
+	}
+	if !strings.Contains(hint, "Esc to cancel") {
+		t.Fatalf("expected Esc instruction, got %q", hint)
+	}
+	expected := fmt.Sprintf("vehicle,%.5f,%.5f,%.1f", 4+enemyOffset, 5+enemyOffset, 6.0)
+	if !strings.Contains(hint, expected) {
+		t.Fatalf("expected default value %q in hint, got %q", expected, hint)
 	}
 }


### PR DESCRIPTION
## Summary
- show enemy information beneath drone telemetry in the TUI
- open an enemy spawn dialog with the `e` hotkey and forward spawn requests to the simulator
- document available TUI hotkeys and clarify spawn dialog input (`type,lat,lon,alt` then Enter)
- pre-populate spawn dialog near the latest drone for quicker enemy creation

## Testing
- `go vet ./...` *(hang, aborted after module download)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6890ea392fa083238904f4841e290212