### PR TITLE
feat(sim): add mission writer support

### DIFF
--- a/cmd/droneops-sim/writer_test.go
+++ b/cmd/droneops-sim/writer_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNewWritersPrintOnly(t *testing.T) {
-	tw, dw, cleanup, err := newWriters(nil, true, "", true, true, true)
+	tw, dw, mw, cleanup, err := newWriters(nil, true, "", true, true, true)
 	if err != nil {
 		t.Fatalf("newWriters returned error: %v", err)
 	}
@@ -21,12 +21,15 @@ func TestNewWritersPrintOnly(t *testing.T) {
 	}
 	if _, ok := dw.(*sim.JSONStdoutWriter); !ok {
 		t.Fatalf("expected *sim.JSONStdoutWriter, got %T", dw)
+	}
+	if _, ok := mw.(*sim.JSONStdoutWriter); !ok {
+		t.Fatalf("expected mission writer *sim.JSONStdoutWriter, got %T", mw)
 	}
 }
 
 func TestNewWritersGreptimeFallback(t *testing.T) {
 	t.Setenv("GREPTIMEDB_ENDPOINT", "")
-	tw, dw, cleanup, err := newWriters(nil, false, "", true, true, true)
+	tw, dw, mw, cleanup, err := newWriters(nil, false, "", true, true, true)
 	if err != nil {
 		t.Fatalf("newWriters returned error: %v", err)
 	}
@@ -36,19 +39,25 @@ func TestNewWritersGreptimeFallback(t *testing.T) {
 	}
 	if _, ok := dw.(*sim.JSONStdoutWriter); !ok {
 		t.Fatalf("expected *sim.JSONStdoutWriter, got %T", dw)
+	}
+	if _, ok := mw.(*sim.JSONStdoutWriter); !ok {
+		t.Fatalf("expected mission writer *sim.JSONStdoutWriter, got %T", mw)
 	}
 }
 
 func TestNewWritersLogFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "telemetry.log")
-	tw, _, cleanup, err := newWriters(nil, true, path, true, true, true)
+	tw, _, mw, cleanup, err := newWriters(nil, true, path, true, true, true)
 	if err != nil {
 		t.Fatalf("newWriters returned error: %v", err)
 	}
 	defer cleanup()
 	if _, ok := tw.(*sim.MultiWriter); !ok {
 		t.Fatalf("expected *sim.MultiWriter, got %T", tw)
+	}
+	if _, ok := mw.(*sim.MultiWriter); !ok {
+		t.Fatalf("expected mission writer *sim.MultiWriter, got %T", mw)
 	}
 	row := telemetry.TelemetryRow{ClusterID: "c1", DroneID: "d1", Timestamp: time.Now()}
 	if err := tw.Write(row); err != nil {
@@ -79,7 +88,7 @@ func TestNewWritersLogFile(t *testing.T) {
 }
 
 func TestNewWritersDisableDetections(t *testing.T) {
-	tw, dw, cleanup, err := newWriters(nil, true, "", false, true, true)
+	tw, dw, mw, cleanup, err := newWriters(nil, true, "", false, true, true)
 	if err != nil {
 		t.Fatalf("newWriters returned error: %v", err)
 	}
@@ -89,5 +98,8 @@ func TestNewWritersDisableDetections(t *testing.T) {
 	}
 	if _, ok := tw.(*sim.JSONStdoutWriter); !ok {
 		t.Fatalf("expected *sim.JSONStdoutWriter, got %T", tw)
+	}
+	if _, ok := mw.(*sim.JSONStdoutWriter); !ok {
+		t.Fatalf("expected mission writer *sim.JSONStdoutWriter, got %T", mw)
 	}
 }

--- a/internal/sim/file_writer.go
+++ b/internal/sim/file_writer.go
@@ -135,6 +135,21 @@ func (f *FileWriter) WriteStates(rows []telemetry.SimulationStateRow) error {
 	return nil
 }
 
+// WriteMission logs a mission metadata row to the telemetry file.
+func (f *FileWriter) WriteMission(row telemetry.MissionRow) error {
+	return f.teleEnc.Encode(row)
+}
+
+// WriteMissions logs multiple mission metadata rows.
+func (f *FileWriter) WriteMissions(rows []telemetry.MissionRow) error {
+	for _, r := range rows {
+		if err := f.WriteMission(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Close closes any underlying files.
 func (f *FileWriter) Close() error {
 	var err error

--- a/internal/sim/greptime_writer_test.go
+++ b/internal/sim/greptime_writer_test.go
@@ -58,3 +58,29 @@ func TestGreptimeWriterSwarmEventsJSON(t *testing.T) {
 		t.Fatalf("drone_ids = %s, want %s", got, want)
 	}
 }
+
+func TestGreptimeWriterMissions(t *testing.T) {
+	rows := []telemetry.MissionRow{{
+		ID:          "m1",
+		Name:        "Mission",
+		Objective:   "Obj",
+		Description: "Desc",
+		Region:      telemetry.Region{Name: "R", CenterLat: 1, CenterLon: 2, RadiusKM: 3},
+	}}
+
+	m := &mockGreptimeClient{}
+	w := &GreptimeDBWriter{client: m, missionTable: "missions"}
+
+	if err := w.WriteMissions(rows); err != nil {
+		t.Fatalf("WriteMissions: %v", err)
+	}
+	if m.table == nil {
+		t.Fatalf("expected table to be captured")
+	}
+	if got := m.table.GetRows().Rows[0].Values[0].GetStringValue(); got != "m1" {
+		t.Fatalf("id = %s, want m1", got)
+	}
+	if got := m.table.GetRows().Rows[0].Values[4].GetStringValue(); got != "R" {
+		t.Fatalf("region_name = %s, want R", got)
+	}
+}

--- a/internal/sim/mission_writer.go
+++ b/internal/sim/mission_writer.go
@@ -1,0 +1,13 @@
+package sim
+
+import "droneops-sim/internal/telemetry"
+
+// MissionWriter handles mission metadata rows.
+type MissionWriter interface {
+	WriteMission(telemetry.MissionRow) error
+}
+
+// Optional: Mission writers may support batch mode.
+type batchMissionWriter interface {
+	WriteMissions([]telemetry.MissionRow) error
+}

--- a/internal/sim/stdout_json_writer.go
+++ b/internal/sim/stdout_json_writer.go
@@ -79,3 +79,18 @@ func (w *JSONStdoutWriter) WriteStates(rows []telemetry.SimulationStateRow) erro
 	}
 	return nil
 }
+
+// WriteMission outputs a mission row in JSON format.
+func (w *JSONStdoutWriter) WriteMission(row telemetry.MissionRow) error {
+	data, _ := json.Marshal(row)
+	fmt.Fprintln(w.out, string(data))
+	return nil
+}
+
+// WriteMissions outputs multiple mission rows in JSON format.
+func (w *JSONStdoutWriter) WriteMissions(rows []telemetry.MissionRow) error {
+	for _, r := range rows {
+		_ = w.WriteMission(r)
+	}
+	return nil
+}

--- a/internal/sim/stdout_writer_test.go
+++ b/internal/sim/stdout_writer_test.go
@@ -30,6 +30,7 @@ func TestJSONStdoutWriter(t *testing.T) {
 	dRow := enemy.DetectionRow{ClusterID: "c1", DroneID: "d1", EnemyID: "e1", Timestamp: ts}
 	sRow := telemetry.SwarmEventRow{ClusterID: "c1", EventType: telemetry.SwarmEventAssignment, DroneIDs: []string{"d1"}, EnemyID: "e1", Timestamp: ts}
 	stRow := telemetry.SimulationStateRow{ClusterID: "c1", MessagesSent: 1, ChaosMode: true, Timestamp: ts}
+	mRow := telemetry.MissionRow{ID: "m1", Name: "Mission", Objective: "Obj", Description: "Desc", Region: telemetry.Region{Name: "R", CenterLat: 1, CenterLon: 2, RadiusKM: 3}}
 
 	cases := []struct {
 		name   string
@@ -88,6 +89,20 @@ func TestJSONStdoutWriter(t *testing.T) {
 				}
 				if got.MessagesSent != stRow.MessagesSent || got.ChaosMode != stRow.ChaosMode {
 					t.Fatalf("unexpected state row: %#v", got)
+				}
+				return nil
+			},
+		},
+		{
+			name:  "mission",
+			write: func(w *JSONStdoutWriter) error { return w.WriteMission(mRow) },
+			decode: func(b []byte) error {
+				var got telemetry.MissionRow
+				if err := json.Unmarshal(b, &got); err != nil {
+					return err
+				}
+				if got.ID != mRow.ID || got.Region.Name != mRow.Region.Name {
+					t.Fatalf("unexpected mission row: %#v", got)
 				}
 				return nil
 			},


### PR DESCRIPTION
## Summary
- add MissionWriter interface and implementations for stdout JSON and GreptimeDB writers
- record configured missions at simulator startup
- support mission writing through writer initialization pipeline

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6892599516e0832396366994d43d32e5