### PR TITLE
fix: lower follow confidence for swarm reactions

### DIFF
--- a/config/simulation.yaml
+++ b/config/simulation.yaml
@@ -75,7 +75,7 @@ fleets:
       battery_anomaly_rate: 0.01
 
 # Minimum confidence for drones to engage follow mode
-follow_confidence: 75
+follow_confidence: 60
 
 # Overall mission criticality influencing follow aggressiveness
 mission_criticality: medium

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,7 +87,7 @@ weather_impact: 0.2
 communication_loss: 0.05
 bandwidth_limit: 10
 # Minimum confidence for drones to begin following detected enemies
-follow_confidence: 75
+follow_confidence: 60
 
 # Overall mission criticality influencing follow aggressiveness
 mission_criticality: medium
@@ -100,7 +100,7 @@ swarm_responses:
 ```
 
 `follow_confidence` sets the detection confidence threshold required for a drone
-to switch into follow mode. `mission_criticality` (`low`, `medium`, `high`)
+to switch into follow mode (default: `60`). `mission_criticality` (`low`, `medium`, `high`)
 adjusts how aggressively the swarm adds followers when a threat is detected.
 
 `enemy_count` controls how many hostile entities are simulated in each zone and `detection_radius_m` sets the detection range in meters for each drone. `sensor_noise`, `terrain_occlusion`, and `weather_impact` modify detection confidence to account for sensor errors and environmental effects.

--- a/docs/enemy-detection.md
+++ b/docs/enemy-detection.md
@@ -53,7 +53,7 @@ The following fields in `config/simulation.yaml` control the enemy detection beh
 enemy_detection:
   enemy_count: 5
   detection_radius_m: 1200
-  follow_confidence: 75
+  follow_confidence: 60
   sensor_noise: 0.05
 ```
 


### PR DESCRIPTION
## Summary
- lower follow confidence default so nearby detections trigger swarm events
- document new 60 confidence threshold for enemy detection

## Testing
- `cue vet config/simulation.yaml schemas/simulation.cue`
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689268ce93948323baf7827f8162c500