### PR TITLE
feat: add summary footer to TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It supports:
 - **Observer dashboard** for stepping through mission events, switching perspectives, and injecting commands
 - **Swarm-event logs** for follower assignments, reassignments, and formation changes
 - **Per-tick simulation state metrics** including communication reliability, sensor noise, weather impact, and chaos-mode status
-- **Interactive TUI** with hotkeys (`q` quit, `w` wrap, `s` scroll, `e` spawn enemy via `type,lat,lon,alt` + `Enter`; dialog auto-fills near the latest drone position for quick spawning)
+- **Interactive TUI** with hotkeys (`q` quit, `w` wrap, `s` scroll, `e` spawn enemy via `type,lat,lon,alt` + `Enter`; dialog auto-fills near the latest drone position for quick spawning, `t` toggle summary footer)
 
 This project was designed to support visualization dashboards (e.g., Grafana Geomap panel) and multi-cluster sync scenarios (mission clusters → command cluster).
 


### PR DESCRIPTION
## Summary
- add toggleable summary footer aggregating drone counts, average battery, and mission progress
- document summary toggle key
- test summary footer behavior

## Testing
- `make test`
- `go vet ./...`
- `/root/.local/share/mise/installs/go/1.24.3/bin/cue vet config/simulation.yaml schemas/simulation.cue`


------
https://chatgpt.com/codex/tasks/task_e_689378d890b8832384e60150c2b1a629