### PR TITLE
feat: add summary footer to TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It supports:
 - **Observer dashboard** for stepping through mission events, switching perspectives, and injecting commands
 - **Swarm-event logs** for follower assignments, reassignments, and formation changes
 - **Per-tick simulation state metrics** including communication reliability, sensor noise, weather impact, and chaos-mode status
-- **Interactive TUI** with hotkeys (`q` quit, `w` wrap, `s` scroll, `e` spawn enemy via `type,lat,lon,alt` + `Enter`; dialog auto-fills near the latest drone position for quick spawning)
+- **Interactive TUI** with hotkeys (`q` quit, `w` wrap, `s` scroll, `e` spawn enemy via `type,lat,lon,alt` + `Enter`; dialog auto-fills near the latest drone position for quick spawning, `E` edit/remove enemy via `id,status|delete`, `t` toggle summary footer, `?` help overlay)
 
 This project was designed to support visualization dashboards (e.g., Grafana Geomap panel) and multi-cluster sync scenarios (mission clusters → command cluster).
 

--- a/cmd/droneops-sim/simulate.go
+++ b/cmd/droneops-sim/simulate.go
@@ -119,6 +119,12 @@ var simulateCmd = &cobra.Command{
 		if sp, ok := writer.(sim.EnemySpawner); ok {
 			sp.SetSpawner(simulator.SpawnEnemy)
 		}
+		if rm, ok := writer.(sim.EnemyRemover); ok {
+			rm.SetRemover(simulator.RemoveEnemy)
+		}
+		if up, ok := writer.(sim.EnemyStatusUpdater); ok {
+			up.SetStatusUpdater(simulator.UpdateEnemyStatus)
+		}
 
 		srv := admin.NewServer(simulator)
 		if aw, ok := writer.(sim.AdminStatusWriter); ok {

--- a/internal/enemy/engine.go
+++ b/internal/enemy/engine.go
@@ -34,6 +34,7 @@ func NewEngine(count int, regions []telemetry.Region, r *rand.Rand) *Engine {
 				Position:   randomPosition(r, reg),
 				Confidence: 100,
 				Region:     reg,
+				Status:     EnemyActive,
 			}
 			e.Enemies = append(e.Enemies, en)
 		}
@@ -95,6 +96,7 @@ func (e *Engine) spawnDecoy(parent *Enemy) {
 		Position:   randomStep(e.rand, parent.Position),
 		Confidence: parent.Confidence * 0.5,
 		Region:     parent.Region,
+		Status:     EnemyActive,
 	}
 	e.Enemies = append(e.Enemies, decoy)
 }

--- a/internal/enemy/types.go
+++ b/internal/enemy/types.go
@@ -16,6 +16,16 @@ const (
 	EnemyDecoy   EnemyType = "decoy"
 )
 
+// EnemyStatus represents the activity state of an enemy.
+type EnemyStatus string
+
+const (
+	// EnemyActive indicates the enemy is active in the simulation.
+	EnemyActive EnemyStatus = "active"
+	// EnemyNeutralized indicates the enemy has been neutralized.
+	EnemyNeutralized EnemyStatus = "neutralized"
+)
+
 // Enemy represents one simulated enemy entity.
 type Enemy struct {
 	ID         string
@@ -23,6 +33,7 @@ type Enemy struct {
 	Position   telemetry.Position
 	Confidence float64
 	Region     telemetry.Region
+	Status     EnemyStatus
 }
 
 // DetectionRow describes a drone enemy detection event.

--- a/internal/sim/multi_writer.go
+++ b/internal/sim/multi_writer.go
@@ -183,6 +183,24 @@ func (mw *MultiWriter) SetSpawner(fn func(enemy.Enemy)) {
 	}
 }
 
+// SetRemover forwards enemy removal callbacks to writers that support it.
+func (mw *MultiWriter) SetRemover(fn func(string)) {
+	for _, w := range mw.telewriters {
+		if rm, ok := w.(EnemyRemover); ok {
+			rm.SetRemover(fn)
+		}
+	}
+}
+
+// SetStatusUpdater forwards enemy status update callbacks to writers that support it.
+func (mw *MultiWriter) SetStatusUpdater(fn func(string, enemy.EnemyStatus)) {
+	for _, w := range mw.telewriters {
+		if up, ok := w.(EnemyStatusUpdater); ok {
+			up.SetStatusUpdater(fn)
+		}
+	}
+}
+
 // Close closes underlying writers that support it.
 func (mw *MultiWriter) Close() error {
 	for _, w := range mw.telewriters {

--- a/internal/sim/multi_writer_test.go
+++ b/internal/sim/multi_writer_test.go
@@ -7,10 +7,18 @@ import (
 	"droneops-sim/internal/telemetry"
 )
 
-type stubSpawnWriter struct{ fn func(enemy.Enemy) }
+type stubSpawnWriter struct {
+	fn func(enemy.Enemy)
+	rm func(string)
+	up func(string, enemy.EnemyStatus)
+}
 
 func (s *stubSpawnWriter) Write(telemetry.TelemetryRow) error { return nil }
 func (s *stubSpawnWriter) SetSpawner(f func(enemy.Enemy))     { s.fn = f }
+func (s *stubSpawnWriter) SetRemover(f func(string))          { s.rm = f }
+func (s *stubSpawnWriter) SetStatusUpdater(f func(string, enemy.EnemyStatus)) {
+	s.up = f
+}
 
 func TestMultiWriterSetSpawner(t *testing.T) {
 	s := &stubSpawnWriter{}
@@ -18,5 +26,23 @@ func TestMultiWriterSetSpawner(t *testing.T) {
 	mw.SetSpawner(func(enemy.Enemy) {})
 	if s.fn == nil {
 		t.Fatalf("spawner not forwarded")
+	}
+}
+
+func TestMultiWriterSetRemover(t *testing.T) {
+	s := &stubSpawnWriter{}
+	mw := NewMultiWriter([]TelemetryWriter{s}, nil, nil)
+	mw.SetRemover(func(string) {})
+	if s.rm == nil {
+		t.Fatalf("remover not forwarded")
+	}
+}
+
+func TestMultiWriterSetStatusUpdater(t *testing.T) {
+	s := &stubSpawnWriter{}
+	mw := NewMultiWriter([]TelemetryWriter{s}, nil, nil)
+	mw.SetStatusUpdater(func(string, enemy.EnemyStatus) {})
+	if s.up == nil {
+		t.Fatalf("status updater not forwarded")
 	}
 }

--- a/internal/sim/simulator_test.go
+++ b/internal/sim/simulator_test.go
@@ -963,3 +963,24 @@ func TestSimulatorSpawnEnemy(t *testing.T) {
 		t.Fatalf("expected enemy to be spawned")
 	}
 }
+
+func TestSimulatorRemoveEnemy(t *testing.T) {
+	sim := &Simulator{rand: rand.New(rand.NewSource(1))}
+	sim.SpawnEnemy(enemy.Enemy{ID: "e1", Type: enemy.EnemyPerson})
+	sim.RemoveEnemy("e1")
+	if sim.enemyEng == nil || len(sim.enemyEng.Enemies) != 0 {
+		t.Fatalf("enemy not removed")
+	}
+	if _, ok := sim.enemyObjects["e1"]; ok {
+		t.Fatalf("enemy still present in objects")
+	}
+}
+
+func TestSimulatorUpdateEnemyStatus(t *testing.T) {
+	sim := &Simulator{rand: rand.New(rand.NewSource(1))}
+	sim.SpawnEnemy(enemy.Enemy{ID: "e1", Type: enemy.EnemyPerson})
+	sim.UpdateEnemyStatus("e1", enemy.EnemyNeutralized)
+	if sim.enemyEng.Enemies[0].Status != enemy.EnemyNeutralized {
+		t.Fatalf("status not updated")
+	}
+}

--- a/internal/sim/spawner.go
+++ b/internal/sim/spawner.go
@@ -6,3 +6,13 @@ import "droneops-sim/internal/enemy"
 type EnemySpawner interface {
 	SetSpawner(func(enemy.Enemy))
 }
+
+// EnemyRemover allows setting a callback used to remove enemies.
+type EnemyRemover interface {
+	SetRemover(func(string))
+}
+
+// EnemyStatusUpdater allows setting a callback used to update enemy statuses.
+type EnemyStatusUpdater interface {
+	SetStatusUpdater(func(string, enemy.EnemyStatus))
+}


### PR DESCRIPTION
## Summary
- add toggleable summary footer aggregating drone counts, average battery, and mission progress
- document summary toggle key
- test summary footer behavior
- manage enemy list with editable statuses and removal controls via `E` hotkey
- forward enemy removal and status updates through simulator and writers
- add help overlay with `?` hotkey detailing key bindings

## Testing
- `go vet ./...`
- `make test`
- `cue vet config/simulation.yaml schemas/simulation.cue`


------
https://chatgpt.com/codex/tasks/task_e_689378d890b8832384e60150c2b1a629