### PR TITLE
feat: add responsive layout toggles

### DIFF
--- a/internal/sim/tui_writer_test.go
+++ b/internal/sim/tui_writer_test.go
@@ -441,3 +441,29 @@ func TestHelpToggle(t *testing.T) {
 		t.Fatalf("help not toggled off")
 	}
 }
+
+func TestToggleSections(t *testing.T) {
+	cfg := &config.SimulationConfig{Missions: []config.Mission{{ID: "m1", Name: "M1"}}}
+	m := newTUIModel(cfg, map[string]string{"m1": colorBlue})
+	mi, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 40})
+	m = mi.(tuiModel)
+	if !strings.Contains(m.renderHeader(), "Missions") {
+		t.Fatalf("expected missions in header")
+	}
+	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	m = mi.(tuiModel)
+	if strings.Contains(m.renderHeader(), "Missions") {
+		t.Fatalf("missions not hidden")
+	}
+	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m = mi.(tuiModel)
+	if strings.Contains(m.View(), "Enemies:") {
+		t.Fatalf("enemies section not hidden")
+	}
+	// toggle enemies back on
+	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m = mi.(tuiModel)
+	if !strings.Contains(m.View(), "Enemies:") {
+		t.Fatalf("enemies section not shown")
+	}
+}


### PR DESCRIPTION
## Summary
- allow mission tree and enemy sections to be hidden via `m` and `n`
- update TUI layout and footer indicators for responsive sections
- add tests for section toggling

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68939ca2e0888323a29e7435282ec721