### PR TITLE
feat: add TUI map view

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It supports:
 - **Observer dashboard** for stepping through mission events, switching perspectives, and injecting commands
 - **Swarm-event logs** for follower assignments, reassignments, and formation changes
 - **Per-tick simulation state metrics** including communication reliability, sensor noise, weather impact, and chaos-mode status
-- **Interactive TUI** with hotkeys (`q` quit, `w` wrap, `s` scroll, `e` spawn enemy via `type,lat,lon,alt` + `Enter`; dialog auto-fills near the latest drone position for quick spawning, `E` edit/remove enemy via `id,status|delete`, `t` toggle summary footer, `?` help overlay)
+- **Interactive TUI** with hotkeys (`q` quit, `w` wrap, `s` scroll, `e` spawn enemy via `type,lat,lon,alt` + `Enter`; dialog auto-fills near the latest drone position for quick spawning, `E` edit/remove enemy via `id,status|delete`, `t` toggle summary footer, `p` toggle a battlefield map with colored drone arrows and red enemy markers, `?` help overlay)
 
 This project was designed to support visualization dashboards (e.g., Grafana Geomap panel) and multi-cluster sync scenarios (mission clusters → command cluster).
 

--- a/internal/sim/stdout_color_writer.go
+++ b/internal/sim/stdout_color_writer.go
@@ -34,7 +34,7 @@ type ColorStdoutWriter struct {
 	colorIdx      int
 }
 
-var missionPalette = []string{colorRed, colorGreen, colorYellow, colorBlue, colorMagenta, colorCyan}
+var missionPalette = []string{colorGreen, colorCyan, colorBlue, colorMagenta, colorYellow, colorRed}
 
 // NewColorStdoutWriter creates a ColorStdoutWriter writing to os.Stdout.
 func NewColorStdoutWriter(cfg *config.SimulationConfig) *ColorStdoutWriter {

--- a/internal/sim/tui_writer_test.go
+++ b/internal/sim/tui_writer_test.go
@@ -498,3 +498,26 @@ func TestToggleSections(t *testing.T) {
 		t.Fatalf("enemies section not shown")
 	}
 }
+
+func TestMapViewRendering(t *testing.T) {
+	cfg := &config.SimulationConfig{Missions: []config.Mission{{ID: "m1"}}}
+	m := newTUIModel(cfg, map[string]string{"m1": colorGreen})
+	mi, _ := m.Update(tea.WindowSizeMsg{Width: 20, Height: 10})
+	m = mi.(tuiModel)
+	row := telemetry.TelemetryRow{DroneID: "d1", MissionID: "m1", Lat: 0, Lon: 0, HeadingDeg: 0}
+	mi, _ = m.Update(telemetryMsg{TelemetryRow: row})
+	m = mi.(tuiModel)
+	m.enemies = []enemy.Enemy{{ID: "e1", Type: enemy.EnemyVehicle, Position: telemetry.Position{Lat: 0, Lon: 0.1}, Status: enemy.EnemyActive}}
+	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	m = mi.(tuiModel)
+	if !m.showMap {
+		t.Fatalf("map view not enabled")
+	}
+	view := m.View()
+	if !strings.Contains(view, colorGreen+"^"+colorReset) {
+		t.Fatalf("missing drone marker: %q", view)
+	}
+	if !strings.Contains(view, colorRed+"X"+colorReset) {
+		t.Fatalf("missing enemy marker: %q", view)
+	}
+}


### PR DESCRIPTION
## Summary
- track drone positions and add battlefield map rendering
- toggle map view via `p` and document hotkey
- enrich map markers with colored drone arrows and red enemy icons

## Testing
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6893b9fd86f48323a98778010fe51fa7