### PR TITLE
feat: enhance TUI map with gridlines and scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It supports:
 - **Observer dashboard** for stepping through mission events, switching perspectives, and injecting commands
 - **Swarm-event logs** for follower assignments, reassignments, and formation changes
 - **Per-tick simulation state metrics** including communication reliability, sensor noise, weather impact, and chaos-mode status
-- **Interactive TUI** with hotkeys (`q` quit, `w` wrap, `s` scroll, `e` spawn enemy via `type,lat,lon,alt` + `Enter`; dialog auto-fills near the latest drone position for quick spawning, `E` edit/remove enemy via `id,status|delete`, `t` toggle summary footer, `p` toggle a battlefield map with colored drone arrows and red enemy markers, `?` help overlay)
+- **Interactive TUI** with hotkeys (`q` quit, `w` wrap, `s` scroll, `e` spawn enemy via `type,lat,lon,alt` + `Enter`; dialog auto-fills near the latest drone position for quick spawning, `E` edit/remove enemy via `id,status|delete`, `t` toggle summary footer, `p` toggle a battlefield map with gridlines, north indicator, scale bar, colored drone arrows, and red enemy markers, `?` help overlay)
 
 This project was designed to support visualization dashboards (e.g., Grafana Geomap panel) and multi-cluster sync scenarios (mission clusters → command cluster).
 

--- a/internal/sim/tui_writer_test.go
+++ b/internal/sim/tui_writer_test.go
@@ -158,6 +158,36 @@ func TestTelemetrySectionsCapped(t *testing.T) {
 	}
 }
 
+func TestRenderMapAddsContext(t *testing.T) {
+	cfg := &config.SimulationConfig{}
+	m := newTUIModel(cfg, nil)
+	mi, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	m = mi.(tuiModel)
+	m.dronePositions["d1"] = telemetry.Position{Lat: 10, Lon: 20}
+	m.droneHeadings["d1"] = 0
+	out := m.renderMap()
+	if !strings.Contains(out, "N↑") {
+		t.Fatalf("expected north indicator in map: %q", out)
+	}
+	if !strings.Contains(out, "Scale:") {
+		t.Fatalf("expected scale bar in map: %q", out)
+	}
+	lines := strings.Split(out, "\n")
+	hasGrid := false
+	for _, line := range lines[1:] {
+		if strings.HasPrefix(line, "Scale:") {
+			break
+		}
+		if strings.ContainsAny(line, "|-+") {
+			hasGrid = true
+			break
+		}
+	}
+	if !hasGrid {
+		t.Fatalf("expected gridlines in map: %q", out)
+	}
+}
+
 func TestWrapToggle(t *testing.T) {
 	cfg := &config.SimulationConfig{
 		Missions: []config.Mission{{ID: "m1", Name: "M1", Description: "alpha beta gamma delta epsilon zeta"}},


### PR DESCRIPTION
## Summary
- overlay latitude/longitude gridlines on battlefield map
- add north indicator and scale bar for orientation
- document new map features and test coverage

## Testing
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6894383d9f108323b67a42f26e6cfabd