### PR TITLE
feat(sim): add drone trails and detection radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It supports:
 - **Observer dashboard** for stepping through mission events, switching perspectives, and injecting commands
 - **Swarm-event logs** for follower assignments, reassignments, and formation changes
 - **Per-tick simulation state metrics** including communication reliability, sensor noise, weather impact, and chaos-mode status
-- **Interactive TUI** with hotkeys (`q` quit, `w` wrap, `s` scroll, `e` spawn enemy via `type,lat,lon,alt` + `Enter`; dialog auto-fills near the latest drone position for quick spawning, `E` edit/remove enemy via `id,status|delete`, `t` toggle summary footer, `p` toggle a battlefield map with gridlines, north indicator, scale bar, mission-colored drone arrows shaded by battery level with altitude-aware shapes, distinct enemy status markers, `?` help overlay)
+- **Interactive TUI** with hotkeys (`q` quit, `w` wrap, `s` scroll, `e` spawn enemy via `type,lat,lon,alt` + `Enter`; dialog auto-fills near the latest drone position for quick spawning, `E` edit/remove enemy via `id,status|delete`, `t` toggle summary footer, `p` toggle a battlefield map with gridlines, north indicator, scale bar, mission-colored drone arrows shaded by battery level with altitude-aware shapes, distinct enemy status markers, optional detection range circles and recent drone trails, `?` help overlay)
 
 This project was designed to support visualization dashboards (e.g., Grafana Geomap panel) and multi-cluster sync scenarios (mission clusters → command cluster).
 

--- a/internal/sim/tui_writer_test.go
+++ b/internal/sim/tui_writer_test.go
@@ -188,6 +188,26 @@ func TestRenderMapAddsContext(t *testing.T) {
 	}
 }
 
+func TestRenderMapShowsDetectionAndTrails(t *testing.T) {
+	cfg := &config.SimulationConfig{DetectionRadiusM: 1000}
+	m := newTUIModel(cfg, nil)
+	mi, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	m = mi.(tuiModel)
+	m.dronePositions["d1"] = telemetry.Position{Lat: 10, Lon: 20}
+	m.droneHeadings["d1"] = 0
+	m.droneTrails["d1"] = []telemetry.Position{{Lat: 10.001, Lon: 20.001}}
+	m.mapShowDetection = true
+	m.mapShowTrails = true
+	m.initMapViewport()
+	out := m.renderMap()
+	if strings.Count(out, "*") < 2 {
+		t.Fatalf("expected detection radius in map: %q", out)
+	}
+	if strings.Count(out, "·") < 2 {
+		t.Fatalf("expected trail in map: %q", out)
+	}
+}
+
 func TestWrapToggle(t *testing.T) {
 	cfg := &config.SimulationConfig{
 		Missions: []config.Mission{{ID: "m1", Name: "M1", Description: "alpha beta gamma delta epsilon zeta"}},


### PR DESCRIPTION
## Summary
- track recent drone positions and display trails on the TUI map
- optionally draw detection-radius circles around drones
- document new map features and key bindings

## Testing
- `go vet ./...`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68944bfc53808323ba0f839f2c532795