### PR TITLE
feat(sim): improve TUI footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It supports:
 - **Observer dashboard** for stepping through mission events, switching perspectives, and injecting commands
 - **Swarm-event logs** for follower assignments, reassignments, and formation changes
 - **Per-tick simulation state metrics** including communication reliability, sensor noise, weather impact, and chaos-mode status
-- **Interactive TUI** with hotkeys (`q` quit, `w` wrap, `s` scroll, `e` spawn enemy via `type,lat,lon,alt` + `Enter`; dialog auto-fills near the latest drone position for quick spawning, `E` edit/remove enemy via `id,status|delete`, `t` toggle summary footer, `p` toggle a battlefield map with gridlines, north indicator, scale bar, mission-colored drone arrows shaded by battery level with altitude-aware shapes, distinct enemy status markers, optional detection range circles and recent drone trails, `?` help overlay)
+ - **Interactive TUI** with hotkeys (`q` quit, `w` wrap, `s` scroll, `e` spawn enemy via `type,lat,lon,alt` + `Enter`; dialog auto-fills near the latest drone position for quick spawning, `E` edit/remove enemy via `id,status|delete`, `t` toggle summary footer (enabled by default), `p` toggle a battlefield map with gridlines, north indicator, scale bar, mission-colored drone arrows shaded by battery level with altitude-aware shapes, distinct enemy status markers, optional detection range circles and recent drone trails, `h/?` help overlay)
 
 This project was designed to support visualization dashboards (e.g., Grafana Geomap panel) and multi-cluster sync scenarios (mission clusters → command cluster).
 

--- a/internal/sim/tui_writer.go
+++ b/internal/sim/tui_writer.go
@@ -334,6 +334,7 @@ func newTUIModel(cfg *config.SimulationConfig, missionColors map[string]string) 
 		missionTotals:    missionTotals,
 		missionCounts:    make(map[string]map[string]struct{}),
 		detectionCounts:  make(map[string]int),
+		summary:          true,
 	}
 	return m
 }
@@ -890,11 +891,6 @@ func (m tuiModel) renderBottom() string {
 		summaryColor = lipgloss.Color("10")
 	}
 	summaryIndicator := lipgloss.NewStyle().Foreground(summaryColor).Render("●")
-	helpColor := lipgloss.Color("9")
-	if m.help {
-		helpColor = lipgloss.Color("10")
-	}
-	helpIndicator := lipgloss.NewStyle().Foreground(helpColor).Render("●")
 	missionsColor := lipgloss.Color("10")
 	if !m.showMissions {
 		missionsColor = lipgloss.Color("9")
@@ -912,7 +908,8 @@ func (m tuiModel) renderBottom() string {
 		colorMagenta, m.state.SensorNoise, colorReset,
 		colorCyan, m.state.WeatherImpact, colorReset,
 		colorRed, m.state.ChaosMode, colorReset)
-	line := fmt.Sprintf("%s | Admin UI %s | Wrap %s | Scroll %s | Summary %s | Help %s | Missions %s | Enemies %s", state, adminIndicator, wrapIndicator, scrollIndicator, summaryIndicator, helpIndicator, missionsIndicator, enemiesIndicator)
+	helpHint := fmt.Sprintf("%s(h)elp%s", colorBlue, colorReset)
+	line := fmt.Sprintf("%s | Admin UI %s | Wrap %s | Scroll %s | Summary %s | Missions %s | Enemies %s | %s", state, adminIndicator, wrapIndicator, scrollIndicator, summaryIndicator, missionsIndicator, enemiesIndicator, helpHint)
 	if m.summary {
 		return fmt.Sprintf("%s\n%s", m.renderSummary(), line)
 	}

--- a/internal/sim/tui_writer_test.go
+++ b/internal/sim/tui_writer_test.go
@@ -413,14 +413,8 @@ func TestSummaryToggle(t *testing.T) {
 	mi, _ = m.Update(telemetryMsg{telemetry.TelemetryRow{DroneID: "d2", MissionID: "m2", Battery: 40}})
 	m = mi.(tuiModel)
 	bottom := m.renderBottom()
-	if strings.Contains(bottom, "SUMMARY") {
-		t.Fatalf("summary should be hidden by default")
-	}
-	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
-	m = mi.(tuiModel)
-	bottom = m.renderBottom()
 	if !strings.Contains(bottom, "SUMMARY") {
-		t.Fatalf("summary not shown after toggle: %q", bottom)
+		t.Fatalf("summary should be shown by default: %q", bottom)
 	}
 	if !strings.Contains(bottom, fmt.Sprintf("%sdrones=%d%s", colorGreen, 2, colorReset)) {
 		t.Fatalf("missing drone count: %q", bottom)
@@ -440,6 +434,21 @@ func TestSummaryToggle(t *testing.T) {
 	if !strings.Contains(bottom, fmt.Sprintf("%s%s%s=1/3", colorGreen, "m2", colorReset)) {
 		t.Fatalf("missing mission m2 progress: %q", bottom)
 	}
+	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	m = mi.(tuiModel)
+	bottom = m.renderBottom()
+	if strings.Contains(bottom, "SUMMARY") {
+		t.Fatalf("summary not hidden after toggle: %q", bottom)
+	}
+}
+
+func TestHelpHintInFooter(t *testing.T) {
+	cfg := &config.SimulationConfig{}
+	m := newTUIModel(cfg, map[string]string{})
+	bottom := m.renderBottom()
+	if !strings.Contains(bottom, "(h)elp") {
+		t.Fatalf("missing help hint: %q", bottom)
+	}
 }
 
 func TestSummaryIncludesEnemyAndDetectionStats(t *testing.T) {
@@ -447,8 +456,6 @@ func TestSummaryIncludesEnemyAndDetectionStats(t *testing.T) {
 	m := newTUIModel(cfg, map[string]string{"m1": colorRed})
 	m.enemies = []enemy.Enemy{{ID: "e1", Status: enemy.EnemyActive}, {ID: "e2", Status: enemy.EnemyNeutralized}}
 	mi, _ := m.Update(detectionMsg{line: "det", row: enemy.DetectionRow{DroneID: "d1", Timestamp: time.Unix(0, 0).UTC()}})
-	m = mi.(tuiModel)
-	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
 	m = mi.(tuiModel)
 	bottom := m.renderBottom()
 	if !strings.Contains(bottom, fmt.Sprintf("%senemies=%d%s", colorRed, 1, colorReset)) {


### PR DESCRIPTION
## Summary
- enable summary footer by default
- replace footer help indicator with explicit (h)elp hint
- document TUI hotkeys including default summary and h/? help overlay

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689459e6d384832384551d69633600a8