### PR TITLE
feat(tui): add eight-direction heading icons

### DIFF
--- a/internal/sim/tui_writer.go
+++ b/internal/sim/tui_writer.go
@@ -955,14 +955,22 @@ func headingIcon(h float64) string {
 		h += 360
 	}
 	switch {
-	case h >= 45 && h < 135:
-		return ">"
-	case h >= 135 && h < 225:
-		return "v"
-	case h >= 225 && h < 315:
-		return "<"
+	case h >= 22.5 && h < 67.5:
+		return "↗"
+	case h >= 67.5 && h < 112.5:
+		return "→"
+	case h >= 112.5 && h < 157.5:
+		return "↘"
+	case h >= 157.5 && h < 202.5:
+		return "↓"
+	case h >= 202.5 && h < 247.5:
+		return "↙"
+	case h >= 247.5 && h < 292.5:
+		return "←"
+	case h >= 292.5 && h < 337.5:
+		return "↖"
 	default:
-		return "^"
+		return "↑"
 	}
 }
 
@@ -970,14 +978,22 @@ func altitudeIcon(h, alt float64) string {
 	icon := headingIcon(h)
 	if alt >= highAltThreshold {
 		switch icon {
-		case "^":
-			return "▲"
-		case ">":
-			return "▶"
-		case "v":
-			return "▼"
-		case "<":
-			return "◀"
+		case "↑":
+			return "⬆"
+		case "↗":
+			return "⬈"
+		case "→":
+			return "➡"
+		case "↘":
+			return "⬊"
+		case "↓":
+			return "⬇"
+		case "↙":
+			return "⬋"
+		case "←":
+			return "⬅"
+		case "↖":
+			return "⬉"
 		}
 	}
 	return icon
@@ -1229,7 +1245,7 @@ func (m tuiModel) renderMap() string {
 	}
 	legendParts = append(legendParts, fmt.Sprintf("%sX%s=active", colorRed, colorReset))
 	legendParts = append(legendParts, fmt.Sprintf("%sx%s=neutralized", colorYellow, colorReset))
-	legendParts = append(legendParts, "▲=high_alt ^=low_alt")
+	legendParts = append(legendParts, "⬆=high_alt ↑=low_alt")
 	legendParts = append(legendParts, fmt.Sprintf("%s█%s=high_batt %s█%s=med %s█%s=low", bgGreen, colorReset, bgYellow, colorReset, bgRed, colorReset))
 	legendParts = append(legendParts, fmt.Sprintf("%s*%s=detection", colorCyan, colorReset))
 	legendParts = append(legendParts, fmt.Sprintf("%s%s%s=trail", colorGray, trailChar, colorReset))

--- a/internal/sim/tui_writer_test.go
+++ b/internal/sim/tui_writer_test.go
@@ -209,6 +209,47 @@ func TestRenderMapShowsDetectionAndTrails(t *testing.T) {
 	}
 }
 
+func TestHeadingIcon(t *testing.T) {
+	cases := []struct {
+		h    float64
+		icon string
+	}{
+		{0, "↑"},
+		{45, "↗"},
+		{90, "→"},
+		{135, "↘"},
+		{180, "↓"},
+		{225, "↙"},
+		{270, "←"},
+		{315, "↖"},
+	}
+	for _, tt := range cases {
+		if got := headingIcon(tt.h); got != tt.icon {
+			t.Fatalf("heading %v: expected %q, got %q", tt.h, tt.icon, got)
+		}
+	}
+}
+
+func TestAltitudeIcon(t *testing.T) {
+	below := altitudeIcon(0, highAltThreshold-1)
+	if below != "↑" {
+		t.Fatalf("expected low altitude icon ↑, got %q", below)
+	}
+	cases := []struct {
+		h    float64
+		icon string
+	}{
+		{0, "⬆"},
+		{45, "⬈"},
+		{90, "➡"},
+	}
+	for _, tt := range cases {
+		if got := altitudeIcon(tt.h, highAltThreshold); got != tt.icon {
+			t.Fatalf("heading %v: expected %q, got %q", tt.h, tt.icon, got)
+		}
+	}
+}
+
 func TestRenderMapLegendExpanded(t *testing.T) {
 	cfg := &config.SimulationConfig{
 		Missions: []config.Mission{{ID: "m1", Name: "Alpha"}},
@@ -594,7 +635,7 @@ func TestMapViewRendering(t *testing.T) {
 		t.Fatalf("map view not enabled")
 	}
 	view := m.View()
-	if !strings.Contains(view, bgGreen+colorGreen+"^"+colorReset) {
+	if !strings.Contains(view, bgGreen+colorGreen+"↑"+colorReset) {
 		t.Fatalf("missing drone marker: %q", view)
 	}
 	if !strings.Contains(view, colorRed+"X"+colorReset) {
@@ -635,7 +676,7 @@ func TestMapLayerToggle(t *testing.T) {
 	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
 	m = mi.(tuiModel)
 	out := m.renderMap()
-	if !strings.Contains(out, bgGreen+colorGreen+"^"+colorReset) {
+	if !strings.Contains(out, bgGreen+colorGreen+"↑"+colorReset) {
 		t.Fatalf("expected drone marker: %q", out)
 	}
 	if strings.Count(out, colorRed+"X"+colorReset) < 2 {
@@ -646,7 +687,7 @@ func TestMapLayerToggle(t *testing.T) {
 	}
 	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
 	m = mi.(tuiModel)
-	if strings.Contains(m.renderMap(), bgGreen+colorGreen+"^"+colorReset) {
+	if strings.Contains(m.renderMap(), bgGreen+colorGreen+"↑"+colorReset) {
 		t.Fatalf("drone layer not toggled off")
 	}
 	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})


### PR DESCRIPTION
## Summary
- expand headingIcon to handle eight compass directions
- use filled arrow variants for high altitude
- test arrow rendering for headings and altitude thresholds

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68948c0f40788323bd120056894aa7cd