### PR TITLE
feat: replace map markers

### DIFF
--- a/internal/sim/tui_writer.go
+++ b/internal/sim/tui_writer.go
@@ -1142,7 +1142,7 @@ func (m tuiModel) renderMap() string {
 				x := int(float64(x0) + math.Cos(rad)*rx)
 				y := int(float64(y0) + math.Sin(rad)*ry)
 				if y >= 0 && y < mapHeight && x >= 0 && x < width {
-					grid[y][x] = fmt.Sprintf("%s%s%s", c, "o", colorReset)
+					grid[y][x] = fmt.Sprintf("%s%s%s", c, "◯", colorReset)
 				}
 			}
 		}
@@ -1163,7 +1163,7 @@ func (m tuiModel) renderMap() string {
 				x := int(float64(x0) + math.Cos(rad)*rx)
 				y := int(float64(y0) + math.Sin(rad)*ry)
 				if y >= 0 && y < mapHeight && x >= 0 && x < width {
-					grid[y][x] = fmt.Sprintf("%s*%s", colorCyan, colorReset)
+					grid[y][x] = fmt.Sprintf("%s◎%s", colorCyan, colorReset)
 				}
 			}
 		}
@@ -1247,9 +1247,9 @@ func (m tuiModel) renderMap() string {
 	legendParts = append(legendParts, fmt.Sprintf("%sx%s=neutralized", colorYellow, colorReset))
 	legendParts = append(legendParts, "⬆=high_alt ↑=low_alt")
 	legendParts = append(legendParts, fmt.Sprintf("%s█%s=high_batt %s█%s=med %s█%s=low", bgGreen, colorReset, bgYellow, colorReset, bgRed, colorReset))
-	legendParts = append(legendParts, fmt.Sprintf("%s*%s=detection", colorCyan, colorReset))
+	legendParts = append(legendParts, fmt.Sprintf("%s◎%s=detection", colorCyan, colorReset))
 	legendParts = append(legendParts, fmt.Sprintf("%s%s%s=trail", colorGray, trailChar, colorReset))
-	legendParts = append(legendParts, "o=mission_zone")
+	legendParts = append(legendParts, "◯=mission_zone")
 	b.WriteString(strings.Join(legendParts, " "))
 	content := strings.TrimRight(b.String(), "\n")
 	style := lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("8")).Background(lipgloss.Color("235"))

--- a/internal/sim/tui_writer_test.go
+++ b/internal/sim/tui_writer_test.go
@@ -201,7 +201,7 @@ func TestRenderMapShowsDetectionAndTrails(t *testing.T) {
 	m.mapShowTrails = true
 	m.initMapViewport()
 	out := m.renderMap()
-	if strings.Count(out, "*") < 2 {
+	if strings.Count(out, "◎") < 2 {
 		t.Fatalf("expected detection radius in map: %q", out)
 	}
 	if strings.Count(out, "·") < 2 {
@@ -682,7 +682,7 @@ func TestMapLayerToggle(t *testing.T) {
 	if strings.Count(out, colorRed+"X"+colorReset) < 2 {
 		t.Fatalf("expected enemy marker: %q", out)
 	}
-	if !strings.Contains(out, colorGreen+"o"+colorReset) {
+	if !strings.Contains(out, colorGreen+"◯"+colorReset) {
 		t.Fatalf("expected mission zone: %q", out)
 	}
 	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
@@ -697,7 +697,7 @@ func TestMapLayerToggle(t *testing.T) {
 	}
 	mi, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m = mi.(tuiModel)
-	if strings.Contains(m.renderMap(), colorGreen+"o"+colorReset) {
+	if strings.Contains(m.renderMap(), colorGreen+"◯"+colorReset) {
 		t.Fatalf("mission zone layer not toggled off")
 	}
 }


### PR DESCRIPTION
## Summary
- use circular markers for mission zones and detection radius on map
- sync legend and tests with new symbols

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68948eff2b648323a125ce64abfd538a