### PR TITLE
feat: reorganize map legend with new symbols

### DIFF
--- a/internal/sim/tui_writer.go
+++ b/internal/sim/tui_writer.go
@@ -1238,18 +1238,24 @@ func (m tuiModel) renderMap() string {
 	scaleKM := kmPerChar * float64(barChars)
 	b.WriteString(fmt.Sprintf("Scale: |%s| %.0fkm\n", strings.Repeat("-", barChars), scaleKM))
 	var legendParts []string
+	legendParts = append(legendParts,
+		fmt.Sprintf("%s=background", mapBackgroundChar),
+		fmt.Sprintf("%s=grid", mapIntersectionChar),
+		"◯=zone",
+		fmt.Sprintf("%s◎%s=detection", colorCyan, colorReset),
+		"⬆=drone_high ↑=drone_low",
+		fmt.Sprintf("%s█%s=high_batt %s█%s=med %s█%s=low", bgGreen, colorReset, bgYellow, colorReset, bgRed, colorReset),
+		fmt.Sprintf("%s%s%s=trail", colorGray, trailChar, colorReset),
+	)
 	for _, ms := range m.cfg.Missions {
 		if c, ok := m.missionColors[ms.ID]; ok {
-			legendParts = append(legendParts, fmt.Sprintf("%s^%s=%s(%s)", c, colorReset, ms.ID, ms.Name))
+			legendParts = append(legendParts, fmt.Sprintf("%s↑%s=%s(%s)", c, colorReset, ms.ID, ms.Name))
 		}
 	}
-	legendParts = append(legendParts, fmt.Sprintf("%sX%s=active", colorRed, colorReset))
-	legendParts = append(legendParts, fmt.Sprintf("%sx%s=neutralized", colorYellow, colorReset))
-	legendParts = append(legendParts, "⬆=high_alt ↑=low_alt")
-	legendParts = append(legendParts, fmt.Sprintf("%s█%s=high_batt %s█%s=med %s█%s=low", bgGreen, colorReset, bgYellow, colorReset, bgRed, colorReset))
-	legendParts = append(legendParts, fmt.Sprintf("%s◎%s=detection", colorCyan, colorReset))
-	legendParts = append(legendParts, fmt.Sprintf("%s%s%s=trail", colorGray, trailChar, colorReset))
-	legendParts = append(legendParts, "◯=mission_zone")
+	legendParts = append(legendParts,
+		fmt.Sprintf("%sX%s=active", colorRed, colorReset),
+		fmt.Sprintf("%sx%s=neutralized", colorYellow, colorReset),
+	)
 	b.WriteString(strings.Join(legendParts, " "))
 	content := strings.TrimRight(b.String(), "\n")
 	style := lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("8")).Background(lipgloss.Color("235"))

--- a/internal/sim/tui_writer_test.go
+++ b/internal/sim/tui_writer_test.go
@@ -258,17 +258,21 @@ func TestRenderMapLegendExpanded(t *testing.T) {
 	mi, _ := m.Update(tea.WindowSizeMsg{Width: 60, Height: 20})
 	m = mi.(tuiModel)
 	out := m.renderMap()
-	if !strings.Contains(out, "m1(Alpha)") {
-		t.Fatalf("expected mission name in legend: %q", out)
+	expected := []string{
+		"m1(Alpha)",
+		"active",
+		"neutralized",
+		"background",
+		"grid",
+		"zone",
+		"detection",
+		"drone_high",
+		"drone_low",
 	}
-	if !strings.Contains(out, "active") {
-		t.Fatalf("expected active enemy legend: %q", out)
-	}
-	if !strings.Contains(out, "neutralized") {
-		t.Fatalf("expected neutralized enemy legend: %q", out)
-	}
-	if !strings.Contains(out, "detection") {
-		t.Fatalf("expected detection legend: %q", out)
+	for _, substr := range expected {
+		if !strings.Contains(out, substr) {
+			t.Fatalf("expected %q in legend: %q", substr, out)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- show background, grid, drone altitude, detection, zone, battery, and trail symbols in map legend
- use arrow icon for mission entries and reorganize legend order
- update legend unit test for new layout

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6894951b0f188323b7113d9d75142e62