### PR TITLE
feat(enemy): cap decoy spawns and support expiration

### DIFF
--- a/internal/enemy/types.go
+++ b/internal/enemy/types.go
@@ -34,6 +34,8 @@ type Enemy struct {
 	Confidence float64
 	Region     telemetry.Region
 	Status     EnemyStatus
+	ParentID   string
+	ExpiresAt  time.Time
 }
 
 // DetectionRow describes a drone enemy detection event.


### PR DESCRIPTION
## Summary
- add per-parent decoy cap and optional lifespan to enemy engine
- remove expired decoys and skip spawning when cap reached
- test decoy count bounds and expiration handling

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6894a677efa48323b1c9ae54dac72134