### PR TITLE
feat: make greptime database configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The simulator can be configured through the following environment variables:
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
 | `GREPTIMEDB_ENDPOINT` | _none_ | Yes (for GreptimeDB) | GreptimeDB gRPC endpoint. If unset, telemetry is printed to STDOUT. |
+| `GREPTIMEDB_DATABASE` | `metrics` | No | GreptimeDB database name to write into. |
 | `GREPTIMEDB_TABLE` | `drone_telemetry` | No | Table for drone telemetry records. |
 | `ENEMY_DETECTION_TABLE` | `enemy_detection` | No | Table storing enemy detection events. |
 | `SWARM_EVENT_TABLE` | `swarm_events` | No | Table storing swarm coordination events. |

--- a/cmd/droneops-sim/writer.go
+++ b/cmd/droneops-sim/writer.go
@@ -74,12 +74,16 @@ func baseWriters(cfg *config.SimulationConfig, printOnly bool) (sim.TelemetryWri
 	}
 
 	endpoint := os.Getenv("GREPTIMEDB_ENDPOINT")
+	database := os.Getenv("GREPTIMEDB_DATABASE")
+	if database == "" {
+		database = "metrics"
+	}
 	table := os.Getenv("GREPTIMEDB_TABLE")
 	detTable := os.Getenv("ENEMY_DETECTION_TABLE")
 	swarmTable := os.Getenv("SWARM_EVENT_TABLE")
 	stateTable := os.Getenv("SIMULATION_STATE_TABLE")
 	missionTable := os.Getenv("MISSIONS_TABLE")
-	w, err := sim.NewGreptimeDBWriter(endpoint, "public", table, detTable, swarmTable, stateTable, missionTable)
+	w, err := sim.NewGreptimeDBWriter(endpoint, database, table, detTable, swarmTable, stateTable, missionTable)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,6 +40,7 @@ To write to GreptimeDB instead, set the endpoint and table variables:
 
 ```bash
 export GREPTIMEDB_ENDPOINT=127.0.0.1:4001
+export GREPTIMEDB_DATABASE=metrics
 export GREPTIMEDB_TABLE=drone_telemetry
 export ENEMY_DETECTION_TABLE=enemy_detection
 ./build/droneops-sim simulate

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,6 +109,7 @@ adjusts how aggressively the swarm adds followers when a threat is detected.
 ### Enemy Detection
 
 Enemy detection events are stored in GreptimeDB when the `GREPTIMEDB_ENDPOINT` variable is set.
+Use `GREPTIMEDB_DATABASE` to select the target database (defaults to `metrics`).
 Use `ENEMY_DETECTION_TABLE` to control the table name (default: `enemy_detection`).
 See [enemy-detection.md](enemy-detection.md) for more details.
 

--- a/docs/helm-deployment.md
+++ b/docs/helm-deployment.md
@@ -47,7 +47,7 @@ The `droneops-sim` project includes a Helm chart for deploying the simulator in 
 
 - The Helm chart uses ConfigMaps to manage simulation and schema configurations.
 - Ensure the Kubernetes cluster has sufficient resources to handle the configured replicas and resource limits.
-- Update the `GREPTIMEDB_ENDPOINT`, `GREPTIMEDB_TABLE`, and `ENEMY_DETECTION_TABLE` environment variables in the deployment if connecting to a real database.
+- Update the `GREPTIMEDB_ENDPOINT`, `GREPTIMEDB_DATABASE`, `GREPTIMEDB_TABLE`, and `ENEMY_DETECTION_TABLE` environment variables in the deployment if connecting to a real database.
 
 For more details, refer to the `helm/droneops-sim` directory and the `values.yaml` file.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,6 +22,7 @@ make run
 
 ```bash
 export GREPTIMEDB_ENDPOINT=127.0.0.1:4001
+export GREPTIMEDB_DATABASE=metrics
 export GREPTIMEDB_TABLE=drone_telemetry
 export ENEMY_DETECTION_TABLE=enemy_detection
 export SWARM_EVENT_TABLE=swarm_events
@@ -39,6 +40,7 @@ Docker run:
 docker build -t droneops-sim:latest .
 docker run --rm \
     -e GREPTIMEDB_ENDPOINT=127.0.0.1:4001 \
+    -e GREPTIMEDB_DATABASE=metrics \
     -e GREPTIMEDB_TABLE=drone_telemetry \
     -e ENEMY_DETECTION_TABLE=enemy_detection \
     -e SWARM_EVENT_TABLE=swarm_events \

--- a/helm/droneops-sim/templates/deployment.yaml
+++ b/helm/droneops-sim/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
         env:
         - name: GREPTIMEDB_ENDPOINT
           value: "127.0.0.1:4001"
+        - name: GREPTIMEDB_DATABASE
+          value: "metrics"
         - name: GREPTIMEDB_TABLE
           value: "drone_telemetry"
         - name: ENEMY_DETECTION_TABLE


### PR DESCRIPTION
## Summary
- make the GreptimeDB database configurable via the GREPTIMEDB_DATABASE environment variable with a default of metrics
- document the new environment variable across guides and set the Helm chart default

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d4d3767cec832388f82f0d33c12363